### PR TITLE
Setup PostgreSQL service in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,24 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_DB: lazona_connector
+          POSTGRES_USER: lazona_connector
+          POSTGRES_PASSWORD: secret
+
     env:
       SECRET_KEY: 'secret_key'
+      DATABASE_URL: postgres://lazona_connector:secret@localhost:5432/lazona_connector
+      DATABASE_DISABLE_SSL: 'true'
 
     steps:
       - uses: actions/checkout@v2

--- a/lazona_connector/settings.py
+++ b/lazona_connector/settings.py
@@ -74,8 +74,10 @@ WSGI_APPLICATION = 'lazona_connector.wsgi.application'
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
 if 'DATABASE_URL' in os.environ:
+    disable_ssl = bool(os.getenv('DATABASE_DISABLE_SSL', default=False))
+
     DATABASES = {
-        'default': dj_database_url.config(conn_max_age=600, ssl_require=True)
+        'default': dj_database_url.config(conn_max_age=600, ssl_require=not disable_ssl)
     }
 
 else:
@@ -85,7 +87,6 @@ else:
             'NAME': 'lazona_connector',
         }
     }
-
 
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators


### PR DESCRIPTION
Allowing to optionally disable SSL connection to PostgreSQL and using that from the Github workflow. This ensures we use SSL by default, which feels safer.