### PR TITLE
Handle ok status but failed koiki requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 .coverage
 htmlcov/
 tags
+session.json
+data.json

--- a/koiki/client.py
+++ b/koiki/client.py
@@ -6,7 +6,7 @@ import json
 from koiki.sender import Sender
 from koiki.recipient import Recipient
 
-HOST = os.getenv('HOST', 'https://testing_host')
+HOST = os.getenv('KOIKI_HOST', 'https://testing_host')
 API_PATH = '/rekis/api'
 
 

--- a/koiki/tests/test_client.py
+++ b/koiki/tests/test_client.py
@@ -32,7 +32,7 @@ class KoikiTest(TestCase):
         responses.add(responses.POST, 'https://testing_host/rekis/api/altaEnvios',
                       json={}, status=200)
 
-        self.assertTrue(Client(self.order).create_delivery())
+        Client(self.order).create_delivery()
         mock_logger.error.assert_not_called()
 
     @responses.activate
@@ -41,11 +41,22 @@ class KoikiTest(TestCase):
         responses.add(responses.POST, 'https://testing_host/rekis/api/altaEnvios',
                       json={'error': 'Bad Request'}, status=400)
 
-        self.assertFalse(Client(self.order).create_delivery())
+        Client(self.order).create_delivery()
+        mock_logger.error.assert_called_once_with(
+            'Failed request. status=%s, body=%s', 400, '{"error": "Bad Request"}')
+
+    @responses.activate
+    @patch('koiki.client.logging', autospec=True)
+    def test_create_delivery_succesful_code_failed_response(self, mock_logger):
+        responses.add(responses.POST, 'https://testing_host/rekis/api/altaEnvios',
+                      json={'respuesta': '102', 'mensaje': 'TOKEN NOT FOUND', 'envios': []},
+                      status=200)
+
+        Client(self.order).create_delivery()
         mock_logger.error.assert_called_once_with(
             'Failed request. status=%s, body=%s',
             400,
-            '{"error": "Bad Request"}'
+            '{"respuesta": "102", "mensaje": "TOKEN NOT FOUND", "envios": []}'
         )
 
     @patch('koiki.client.logging', autospec=True)


### PR DESCRIPTION
Once again, we have to deal with a badly designed API. We'll complain to them but in the meantime, we better handle this.