### PR TITLE
Configure DEBUG based on ENV var

### DIFF
--- a/lazona_connector/settings.py
+++ b/lazona_connector/settings.py
@@ -24,7 +24,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.environ.get('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', '') != 'False'
 
 ALLOWED_HOSTS = ["lazona-connector-staging.herokuapp.com", "127.0.0.1"]
 


### PR DESCRIPTION
This is copied from
https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django/Deployment#getting_your_website_ready_to_publish.

> The value of the DEBUG will be True by default, but will only be False
if the value of the DJANGO_DEBUG environment variable is set to False.
Please note that environment variables are strings and not Python types.
We therefore need to compare strings. The only way to set the DEBUG
variable to False is to actually set it to the string False