### PR TITLE
Provide missing Koiki mandatory request params

### DIFF
--- a/koiki/client.py
+++ b/koiki/client.py
@@ -5,6 +5,7 @@ import json
 
 from koiki.sender import Sender
 from koiki.recipient import Recipient
+from koiki.order import Order
 
 HOST = os.getenv('KOIKI_HOST', 'https://testing_host')
 API_PATH = '/rekis/api'
@@ -15,7 +16,7 @@ class Client():
     label_format = 'PDF'
 
     def __init__(self, order):
-        self.order = order
+        self.order = Order(order)
         self.sender = Sender()
         self.recipient = Recipient(order)
 
@@ -40,8 +41,11 @@ class Client():
         }
 
     def _delivery(self):
-        order = {'numPedido': self.order['order_key']}
-        return {**order, **self.recipient.to_dict(), **self.sender.to_dict()}
+        return {
+            **self.order.to_dict(),
+            **self.recipient.to_dict(),
+            **self.sender.to_dict(),
+        }
 
     def _errored(self, response):
         body = json.loads(response.text)

--- a/koiki/order.py
+++ b/koiki/order.py
@@ -1,0 +1,15 @@
+class Order():
+
+    def __init__(self, order):
+        self.number = order['order_key']
+        self.note = order.get('customer_note', '')
+
+    def to_dict(self):
+        return {
+            'numPedido': self.number,
+            'bultos': 1,
+            'kilos': 1.0,
+            'tipoServicio': '.',
+            'reembolso': 0.0,
+            'observaciones': self.note
+        }

--- a/koiki/recipient.py
+++ b/koiki/recipient.py
@@ -10,7 +10,9 @@ class Recipient():
         return {
             'nombreDesti': self.shipping['first_name'],
             'apellidoDesti': self.shipping['last_name'],
-            'direccionDesti': self._address(),
+            'direccionDesti': self.shipping['address_1'],
+            'direccionAdicionalDesti': self.shipping['address_2'],
+            'numeroCalleDesti': '',
             'codPostalDesti': self.shipping['postcode'],
             'poblacionDesti': self.shipping['city'],
             'provinciaDesti': self.shipping['state'],

--- a/koiki/sender.py
+++ b/koiki/sender.py
@@ -5,6 +5,8 @@ class Sender():
     def to_dict(self):
         return {
             'nombreRemi': 'La Zona',
+            'apellidoRemi': '',
+            'numeroCalleRemi': '',
             'direccionRemi': 'C/ La Zona, 1',
             'codPostalRemi': '08186',
             'poblacionRemi': 'Barcelona',

--- a/koiki/tests/test_client.py
+++ b/koiki/tests/test_client.py
@@ -10,6 +10,7 @@ class KoikiTest(TestCase):
     def setUp(self):
         self.order = {
             'order_key': 'xxx',
+            'customer_note': 'delivery testing',
             'shipping': {
                 'first_name': 'James',
                 'last_name': 'Bond',
@@ -75,9 +76,16 @@ class KoikiTest(TestCase):
                 'envios': [
                     {
                         'numPedido': self.order['order_key'],
+                        'bultos': 1,
+                        'kilos': 1.0,
+                        'tipoServicio': '.',
+                        'reembolso': 0.0,
+                        'observaciones': self.order['customer_note'],
 
                         'nombreRemi': 'La Zona',
+                        'apellidoRemi': '',
                         'direccionRemi': 'C/ La Zona, 1',
+                        'numeroCalleRemi': '',
                         'codPostalRemi': '08186',
                         'poblacionRemi': 'Barcelona',
                         'provinciaRemi': 'Barcelona',
@@ -87,14 +95,16 @@ class KoikiTest(TestCase):
 
                         'nombreDesti': shipping['first_name'],
                         'apellidoDesti': shipping['last_name'],
-                        'direccionDesti': shipping['address_1'] + ' ' + shipping['address_2'],
+                        'direccionDesti': shipping['address_1'],
+                        'direccionAdicionalDesti': shipping['address_2'],
+                        'numeroCalleDesti': '',
                         'codPostalDesti': shipping['postcode'],
                         'poblacionDesti': shipping['city'],
                         'provinciaDesti': shipping['state'],
                         'paisDesti': shipping['country'],
 
                         'telefonoDesti': billing['phone'],
-                        'emailDesti': billing['email']
+                        'emailDesti': billing['email'],
                     }
                 ]
             }

--- a/koiki/tests/test_order.py
+++ b/koiki/tests/test_order.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+from koiki.order import Order
+
+
+class OrderTest(TestCase):
+
+    def setUp(self):
+        self.data = {
+            'order_key': '123x',
+            'customer_note': 'dummy customer note'
+        }
+
+    def test_to_dict(self):
+        order = Order(self.data)
+
+        self.assertEqual(order.to_dict(), {
+            'numPedido': self.data['order_key'],
+            'bultos': 1,
+            'kilos': 1.0,
+            'tipoServicio': '.',
+            'reembolso': 0.0,
+            'observaciones': 'dummy customer note'
+        })

--- a/koiki/tests/test_recipient.py
+++ b/koiki/tests/test_recipient.py
@@ -29,26 +29,9 @@ class RecipientTest(TestCase):
         self.assertEqual(recipient.to_dict(), {
             'nombreDesti': self.shipping['first_name'],
             'apellidoDesti': self.shipping['last_name'],
-            'direccionDesti': self.shipping['address_1'] + ' ' + self.shipping['address_2'],
-            'codPostalDesti': self.shipping['postcode'],
-            'poblacionDesti': self.shipping['city'],
-            'provinciaDesti': self.shipping['state'],
-            'paisDesti': self.shipping['country'],
-
-            'telefonoDesti': self.billing['phone'],
-            'emailDesti': self.billing['email']
-        })
-
-    def test_to_dict_without_address_2(self):
-        self.shipping['address_2'] = ''
-        order = {'shipping': self.shipping, 'billing': self.billing}
-
-        recipient = Recipient(order)
-
-        self.assertEqual(recipient.to_dict(), {
-            'nombreDesti': self.shipping['first_name'],
-            'apellidoDesti': self.shipping['last_name'],
             'direccionDesti': self.shipping['address_1'],
+            'direccionAdicionalDesti': self.shipping['address_2'],
+            'numeroCalleDesti': '',
             'codPostalDesti': self.shipping['postcode'],
             'poblacionDesti': self.shipping['city'],
             'provinciaDesti': self.shipping['state'],

--- a/koiki/tests/test_sender.py
+++ b/koiki/tests/test_sender.py
@@ -10,7 +10,9 @@ class SenderTest(TestCase):
 
         self.assertEqual(sender.to_dict(), {
             'nombreRemi': 'La Zona',
+            'apellidoRemi': '',
             'direccionRemi': 'C/ La Zona, 1',
+            'numeroCalleRemi': '',
             'codPostalRemi': '08186',
             'poblacionRemi': 'Barcelona',
             'provinciaRemi': 'Barcelona',


### PR DESCRIPTION
Follow-up from #14

The API documentation states they are mandatory but the API response don't explicitly say so and we didn't inform them in our initial successful tests. Even the docs show examples passing `null`.

Note I undid the concatenation of address_1 and address_2 because it turns out Koiki's API has also the address optionally split into two fields. I purposefully skipped `direccionAdicionalRemi` though. We don't need it as the sender is hardcoded.