### PR TITLE
Conform to ISO 3166-1 alpha-2 country name format

### DIFF
--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -22,7 +22,7 @@ class DeliveryViewTests(TestCase):
                 'postcode': '08032',
                 'city': 'Barcelona',
                 'state': 'Barcelona',
-                'country': 'Spain'
+                'country': 'ES'
             },
             'billing': {
                 'phone': '666666666',

--- a/koiki/tests/test_client.py
+++ b/koiki/tests/test_client.py
@@ -19,7 +19,7 @@ class KoikiTest(TestCase):
                 'postcode': '08025',
                 'city': 'Barcelona',
                 'state': 'Barcelona',
-                'country': 'Spain'
+                'country': 'ES'
             },
             'billing': {
                 'email': 'email@example.com',

--- a/koiki/tests/test_create_delivery.py
+++ b/koiki/tests/test_create_delivery.py
@@ -18,7 +18,7 @@ class CreateDeliveryTest(TestCase):
                 'postcode': '08025',
                 'city': 'Barcelona',
                 'state': 'Barcelona',
-                'country': 'Spain'
+                'country': 'ES'
             },
             'billing': {
                 'email': 'email@example.com',


### PR DESCRIPTION
This is what both Woocommerce and Koiki do.