### PR TITLE
Authenticate webhooks requests from staging

### DIFF
--- a/api/host_authentication.py
+++ b/api/host_authentication.py
@@ -1,0 +1,21 @@
+from django.contrib.auth.models import User
+from rest_framework import authentication
+from rest_framework import exceptions
+
+
+class HostAuthentication(authentication.BaseAuthentication):
+
+    def authenticate(self, request):
+        source = request.META.get('X-WC-Webhook-Source')
+        if not source:
+            return None
+
+        if 'staging.lazona.coop' not in source:
+            raise exceptions.AuthenticationFailed('Invalid source host')
+
+        try:
+            user = User.objects.get(username='pau')
+        except User.DoesNotExist:
+            raise exceptions.AuthenticationFailed('No such user')
+
+        return (user, None)

--- a/api/tests/test_host_authentication.py
+++ b/api/tests/test_host_authentication.py
@@ -1,0 +1,42 @@
+from django.test import TestCase
+from django.test.client import RequestFactory
+from django.contrib.auth.models import User
+
+from api.host_authentication import HostAuthentication
+import rest_framework
+
+
+class HostAuthenticationTests(TestCase):
+
+    def test_empty_header(self):
+        request = RequestFactory().post('')
+        result = HostAuthentication().authenticate(request)
+        self.assertEqual(result, None)
+
+    def test_invalid_host(self):
+        request = RequestFactory().post('')
+        request.META['X-WC-Webhook-Source'] = 'dummy.lazona.coop'
+
+        self.assertRaises(
+                rest_framework.exceptions.AuthenticationFailed,
+                HostAuthentication().authenticate,
+                request)
+
+    def test_user_does_not_exist(self):
+        request = RequestFactory().post('')
+        request.META['X-WC-Webhook-Source'] = 'staging.lazona.coop'
+
+        self.assertRaises(
+                rest_framework.exceptions.AuthenticationFailed,
+                HostAuthentication().authenticate,
+                request)
+
+    def test_user_exists(self):
+        user = User(username='pau')
+        user.save()
+
+        request = RequestFactory().post('')
+        request.META['X-WC-Webhook-Source'] = 'staging.lazona.coop'
+
+        result = HostAuthentication().authenticate(request)
+        self.assertEqual(result, (user, None))

--- a/api/views.py
+++ b/api/views.py
@@ -1,4 +1,5 @@
 from rest_framework.authentication import TokenAuthentication
+from api.host_authentication import HostAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -8,7 +9,7 @@ from koiki.client import Client
 
 
 class DeliveryList(APIView):
-    authentication_classes = [TokenAuthentication]
+    authentication_classes = [TokenAuthentication, HostAuthentication]
     permission_classes = [IsAuthenticated]
 
     def post(self, request):


### PR DESCRIPTION
This implements a dummy custom authentication class that allows staging webhooks to pass through. This lets us work on #30 while collecting close-to-real traffic so we can debug the integration.