### PR TITLE
Fix how to retrieve HTTP header

### DIFF
--- a/api/host_authentication.py
+++ b/api/host_authentication.py
@@ -6,7 +6,7 @@ from rest_framework import exceptions
 class HostAuthentication(authentication.BaseAuthentication):
 
     def authenticate(self, request):
-        source = request.META.get('X-WC-Webhook-Source')
+        source = request.META.get('HTTP_X_WC_WEBHOOK_SOURCE')
         if not source:
             return None
 

--- a/api/tests/test_host_authentication.py
+++ b/api/tests/test_host_authentication.py
@@ -15,7 +15,7 @@ class HostAuthenticationTests(TestCase):
 
     def test_invalid_host(self):
         request = RequestFactory().post('')
-        request.META['X-WC-Webhook-Source'] = 'dummy.lazona.coop'
+        request.META['HTTP_X_WC_WEBHOOK_SOURCE'] = 'dummy.lazona.coop'
 
         self.assertRaises(
                 rest_framework.exceptions.AuthenticationFailed,
@@ -24,7 +24,7 @@ class HostAuthenticationTests(TestCase):
 
     def test_user_does_not_exist(self):
         request = RequestFactory().post('')
-        request.META['X-WC-Webhook-Source'] = 'staging.lazona.coop'
+        request.META['HTTP_X_WC_WEBHOOK_SOURCE'] = 'staging.lazona.coop'
 
         self.assertRaises(
                 rest_framework.exceptions.AuthenticationFailed,
@@ -36,7 +36,7 @@ class HostAuthenticationTests(TestCase):
         user.save()
 
         request = RequestFactory().post('')
-        request.META['X-WC-Webhook-Source'] = 'staging.lazona.coop'
+        request.META['HTTP_X_WC_WEBHOOK_SOURCE'] = 'staging.lazona.coop'
 
         result = HostAuthentication().authenticate(request)
         self.assertEqual(result, (user, None))


### PR DESCRIPTION
It turns out Django transforms the header names:

> any HTTP headers in the request are converted to META keys by converting all characters to uppercase, replacing any hyphens with underscores and adding an HTTP_ prefix to the name.

source: https://docs.djangoproject.com/en/dev/ref/request-response/#django.http.HttpRequest.META