### PR TITLE
Load host from ENV at runtime

### DIFF
--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -6,11 +6,14 @@ from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 import httpretty
+import os
 
 
 class DeliveryViewTests(TestCase):
 
     def setUp(self):
+        os.environ['KOIKI_HOST'] = 'https://testing_host'
+
         self.url = reverse('deliveries:create')
         self.data = {
             'order_key': 'xxx',

--- a/koiki/client.py
+++ b/koiki/client.py
@@ -8,7 +8,6 @@ from koiki.create_delivery import CreateDelivery
 from koiki.delivery import Delivery
 from koiki.error import Error
 
-HOST = os.getenv('KOIKI_HOST', 'https://testing_host')
 API_PATH = '/rekis/api'
 
 
@@ -18,6 +17,7 @@ class Client():
                  logger=logging.getLogger('django.server')):
         self.order = order
         self.auth_token = auth_token
+        self.host = os.getenv('KOIKI_HOST')
         self.logger = logger
 
     def create_delivery(self):
@@ -37,7 +37,7 @@ class Client():
             return Delivery(response_body['envios'][0])
 
     def _url(self, endpoint_req):
-        return f'{HOST}{API_PATH}{endpoint_req.url()}'
+        return f'{self.host}{API_PATH}{endpoint_req.url()}'
 
     def _authentication(self, endpoint_req):
         return {**endpoint_req.body(), **{'token': self.auth_token}}


### PR DESCRIPTION
So that the tests don't pick up the value we may have defined locally in the `.envrc` and they pass regardless.