### PR TITLE
Use 9-digit phone number in Sender

### DIFF
--- a/koiki/sender.py
+++ b/koiki/sender.py
@@ -2,6 +2,7 @@ class Sender():
 
     """Encapsulates the sender information to be provided to all Koiki deliveries"""
 
+    # Note telefonoRemi can only have 9 digits.
     def to_dict(self):
         return {
             'nombreRemi': 'La Zona',
@@ -13,5 +14,5 @@ class Sender():
             'provinciaRemi': 'Barcelona',
             'paisRemi': 'ES',
             'emailRemi': 'lazona@opcions.org',
-            'telefonoRemi': '+34518888191',
+            'telefonoRemi': '518888191',
         }

--- a/koiki/tests/test_client.py
+++ b/koiki/tests/test_client.py
@@ -113,7 +113,7 @@ class KoikiTest(TestCase):
                         'provinciaRemi': 'Barcelona',
                         'paisRemi': 'ES',
                         'emailRemi': 'lazona@opcions.org',
-                        'telefonoRemi': '+34518888191',
+                        'telefonoRemi': '518888191',
 
                         'nombreDesti': shipping['first_name'],
                         'apellidoDesti': shipping['last_name'],

--- a/koiki/tests/test_sender.py
+++ b/koiki/tests/test_sender.py
@@ -18,5 +18,5 @@ class SenderTest(TestCase):
             'provinciaRemi': 'Barcelona',
             'paisRemi': 'ES',
             'emailRemi': 'lazona@opcions.org',
-            'telefonoRemi': '+34518888191',
+            'telefonoRemi': '518888191',
         })


### PR DESCRIPTION
Closes #37. We mustn't forget to use the vendor's contact details when we change this.