### PR TITLE
Allow ngrok subdomains in ALLOWED_HOSTS

### DIFF
--- a/lazona_connector/settings.py
+++ b/lazona_connector/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get('DJANGO_DEBUG', '') != 'False'
 
-ALLOWED_HOSTS = ["lazona-connector-staging.herokuapp.com", "127.0.0.1"]
+ALLOWED_HOSTS = ["lazona-connector-staging.herokuapp.com", "127.0.0.1", ".ngrok.io"]
 
 
 # Application definition


### PR DESCRIPTION
This way we don't need to add the ngrok's dynamic domain name each time we start a session locally.