### PR TITLE
Fetch vendor details

### DIFF
--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -1,3 +1,8 @@
 import httpretty
+import os
+
+import koiki
 
 httpretty.enable(allow_net_connect=False)
+
+koiki.wcfmmp_api_base = 'https://wcfmmp_testing_host'

--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -1,8 +1,8 @@
 import httpretty
-import os
 
 import koiki
 
 httpretty.enable(allow_net_connect=False)
 
+koiki.host = 'https://testing_host'
 koiki.wcfmmp_api_base = 'https://wcfmmp_testing_host'

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -5,15 +5,12 @@ from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 import httpretty
-import os
 import json
 
 
 class DeliveryViewTests(TestCase):
 
     def setUp(self):
-        os.environ['KOIKI_HOST'] = 'https://testing_host'
-
         self.url = reverse('deliveries:create')
         self.data = {
             'order_key': 'xxx',

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -7,6 +7,8 @@ from rest_framework.test import APIClient
 import httpretty
 import json
 
+import koiki
+
 
 class DeliveryViewTests(TestCase):
 
@@ -52,7 +54,7 @@ class DeliveryViewTests(TestCase):
     def test_successful_request(self):
         httpretty.register_uri(
                 httpretty.GET,
-                'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/6',
+                f'{koiki.wcfmmp_api_base}/wp-json/wcfmmp/v1/settings/id/6',
                 status=200,
                 content_type='application/json',
                 body=json.dumps({

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -6,6 +6,7 @@ from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 import httpretty
 import os
+import json
 
 
 class DeliveryViewTests(TestCase):
@@ -52,6 +53,24 @@ class DeliveryViewTests(TestCase):
         self.client.force_authenticate(user=self.user)
 
     def test_successful_request(self):
+        httpretty.register_uri(
+                httpretty.GET,
+                'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/6',
+                status=200,
+                content_type='application/json',
+                body=json.dumps({
+                    "store_email": "queviure@lazona.coop",
+                    "phone": "",
+                    "address": {
+                        "street_1": "",
+                        "street_2": "",
+                        "city": "",
+                        "zip": "",
+                        "country": "ES",
+                        "state": ""
+                    }
+                })
+        )
         httpretty.register_uri(httpretty.POST, self.api_url, status=200, content_type='text/json')
 
         token = Token.objects.create(key='test token', user=self.user)

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -55,7 +55,7 @@ class DeliveryViewTests(TestCase):
     def test_successful_request(self):
         httpretty.register_uri(
                 httpretty.GET,
-                'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/6',
+                'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/6',
                 status=200,
                 content_type='application/json',
                 body=json.dumps({

--- a/koiki/__init__.py
+++ b/koiki/__init__.py
@@ -1,0 +1,3 @@
+import os
+
+wcfmmp_api_base = os.getenv('WCFMMP_API_BASE')

--- a/koiki/__init__.py
+++ b/koiki/__init__.py
@@ -1,3 +1,4 @@
 import os
 
+host = os.getenv('KOIKI_HOST')
 wcfmmp_api_base = os.getenv('WCFMMP_API_BASE')

--- a/koiki/client.py
+++ b/koiki/client.py
@@ -8,6 +8,8 @@ from koiki.create_delivery import CreateDelivery
 from koiki.delivery import Delivery
 from koiki.error import Error
 
+import koiki
+
 API_PATH = '/rekis/api'
 
 
@@ -17,7 +19,7 @@ class Client():
                  logger=logging.getLogger('django.server')):
         self.order = order
         self.auth_token = auth_token
-        self.host = os.getenv('KOIKI_HOST')
+        self.host = koiki.host
         self.logger = logger
 
     def create_delivery(self):

--- a/koiki/create_delivery.py
+++ b/koiki/create_delivery.py
@@ -45,7 +45,7 @@ class CreateDelivery():
     # Builds a delivery structure from all passed line_items, which are provided by the same vendor
     def _delivery(self, line_items, vendor):
         total_quantity = 0
-        vendor.get()
+        vendor.fetch()
 
         for line_item in line_items:
             total_quantity += line_item.quantity

--- a/koiki/create_delivery.py
+++ b/koiki/create_delivery.py
@@ -25,10 +25,8 @@ class CreateDelivery():
     def _deliveries(self):
         deliveries = []
 
-        for vendor_id in self.by_vendor.keys():
-            line_items = self.by_vendor[vendor_id]
+        for vendor_id, line_items in self.by_vendor.items():
             vendor = line_items[0].vendor
-
             deliveries.append(self._delivery(line_items, vendor))
 
         return deliveries

--- a/koiki/create_delivery.py
+++ b/koiki/create_delivery.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from koiki.models import Sender, Recipient, Shipment
 from koiki.woocommerce.models import LineItem, Shipping, Billing
 
@@ -32,16 +34,11 @@ class CreateDelivery():
         return deliveries
 
     def _by_vendor(self, line_items):
-        by_vendor = {}
+        by_vendor = defaultdict(list)
 
         for line_item in line_items:
             item = LineItem(line_item)
-            vendor_id = item.vendor.id
-
-            if vendor_id in by_vendor.keys():
-                by_vendor[vendor_id].append(item)
-            else:
-                by_vendor[vendor_id] = [item]
+            by_vendor[item.vendor.id].append(item)
 
         return by_vendor
 

--- a/koiki/create_delivery.py
+++ b/koiki/create_delivery.py
@@ -48,6 +48,7 @@ class CreateDelivery():
     # Builds a delivery structure from all passed line_items, which are provided by the same vendor
     def _delivery(self, line_items, vendor):
         total_quantity = 0
+        vendor.get()
 
         for line_item in line_items:
             total_quantity += line_item.quantity

--- a/koiki/models.py
+++ b/koiki/models.py
@@ -3,19 +3,21 @@ class Sender():
     # Note telefonoRemi can only have 9 digits.
     def __init__(self, vendor):
         self.vendor = vendor
+        self.vendor.get()
 
     def to_dict(self):
+
         return {
             'nombreRemi': self.vendor.name,
             'apellidoRemi': '',
             'numeroCalleRemi': '',
-            'direccionRemi': 'C/ La Zona, 1',
-            'codPostalRemi': '08186',
-            'poblacionRemi': 'Barcelona',
-            'provinciaRemi': 'Barcelona',
-            'paisRemi': 'ES',
-            'emailRemi': 'lazona@opcions.org',
-            'telefonoRemi': '518888191',
+            'direccionRemi': self.vendor.address,
+            'codPostalRemi': self.vendor.zip,
+            'poblacionRemi': self.vendor.city,
+            'provinciaRemi': self.vendor.state,
+            'paisRemi': self.vendor.country,
+            'emailRemi': self.vendor.email,
+            'telefonoRemi': self.vendor.phone,
         }
 
 

--- a/koiki/models.py
+++ b/koiki/models.py
@@ -3,7 +3,6 @@ class Sender():
     # Note telefonoRemi can only have 9 digits.
     def __init__(self, vendor):
         self.vendor = vendor
-        self.vendor.get()
 
     def to_dict(self):
 

--- a/koiki/tests/__init__.py
+++ b/koiki/tests/__init__.py
@@ -1,3 +1,8 @@
 import httpretty
+import os
+
+import koiki
 
 httpretty.enable(allow_net_connect=False)
+
+koiki.wcfmmp_api_base = 'https://wcfmmp_testing_host'

--- a/koiki/tests/__init__.py
+++ b/koiki/tests/__init__.py
@@ -1,8 +1,8 @@
 import httpretty
-import os
 
 import koiki
 
 httpretty.enable(allow_net_connect=False)
 
+koiki.host = 'https://testing_host'
 koiki.wcfmmp_api_base = 'https://wcfmmp_testing_host'

--- a/koiki/tests/test_client.py
+++ b/koiki/tests/test_client.py
@@ -4,6 +4,7 @@ import responses
 import json
 
 from koiki.client import Client
+import koiki
 
 
 class KoikiTest(TestCase):
@@ -56,7 +57,7 @@ class KoikiTest(TestCase):
             ],
         }
 
-        responses.add(responses.GET, 'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/6',
+        responses.add(responses.GET, f'{koiki.wcfmmp_api_base}/wp-json/wcfmmp/v1/settings/id/6',
                       status=200,
                       json={
                         "store_email": "queviure@lazona.coop",

--- a/koiki/tests/test_client.py
+++ b/koiki/tests/test_client.py
@@ -59,20 +59,6 @@ class KoikiTest(TestCase):
             ],
         }
 
-        responses.add(responses.GET, 'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/5',
-                      status=200,
-                      json={
-                        "store_email": "detergents@agranel.coop",
-                        "phone": "93333333",
-                        "address": {
-                            "street_1": "Sant Antoni Maria Claret, 175",
-                            "street_2": "",
-                            "city": "Barcelona",
-                            "zip": "08041",
-                            "country": "",
-                            "state": ""
-                        }
-                      })
         responses.add(responses.GET, 'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/6',
                       status=200,
                       json={

--- a/koiki/tests/test_client.py
+++ b/koiki/tests/test_client.py
@@ -59,39 +59,44 @@ class KoikiTest(TestCase):
             ],
         }
 
-        responses.add(responses.GET, 'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/5', status=200, json={
-            "store_email": "detergents@agranel.coop",
-            "phone": "93333333",
-            "address": {
-                "street_1": "Sant Antoni Maria Claret, 175",
-                "street_2": "",
-                "city": "Barcelona",
-                "zip": "08041",
-                "country": "",
-                "state": ""
-            }
-        })
-        responses.add(responses.GET, 'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/6', status=200, json={
-            "store_email": "queviure@lazona.coop",
-            "phone": "",
-            "address": {
-                "street_1": "",
-                "street_2": "",
-                "city": "",
-                "zip": "",
-                "country": "ES",
-                "state": ""
-            }
-        })
+        responses.add(responses.GET, 'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/5',
+                      status=200,
+                      json={
+                        "store_email": "detergents@agranel.coop",
+                        "phone": "93333333",
+                        "address": {
+                            "street_1": "Sant Antoni Maria Claret, 175",
+                            "street_2": "",
+                            "city": "Barcelona",
+                            "zip": "08041",
+                            "country": "",
+                            "state": ""
+                        }
+                      })
+        responses.add(responses.GET, 'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/6',
+                      status=200,
+                      json={
+                        "store_email": "queviure@lazona.coop",
+                        "phone": "",
+                        "address": {
+                            "street_1": "",
+                            "street_2": "",
+                            "city": "",
+                            "zip": "",
+                            "country": "ES",
+                            "state": ""
+                        }
+                      })
 
     @responses.activate
     @patch('koiki.client.logging', autospec=True)
     def test_create_delivery_successful_response(self, mock_logger):
-        responses.add(responses.POST, 'https://testing_host/rekis/api/altaEnvios', status=200, json={
-            'respuesta': '101',
-            'mensaje': 'OK',
-            'envios': [{'numPedido': '123', 'codBarras': 'yyy', 'etiqueta': 'abcd'}]
-        })
+        responses.add(responses.POST, 'https://testing_host/rekis/api/altaEnvios', status=200,
+                      json={
+                        'respuesta': '101',
+                        'mensaje': 'OK',
+                        'envios': [{'numPedido': '123', 'codBarras': 'yyy', 'etiqueta': 'abcd'}]
+                      })
 
         delivery = Client(self.order).create_delivery()
 
@@ -114,8 +119,8 @@ class KoikiTest(TestCase):
 
     @responses.activate
     def test_create_delivery_succesful_code_failed_response(self):
-        responses.add(responses.POST, 'https://testing_host/rekis/api/altaEnvios', status=200, json={
-            'respuesta': '102', 'mensaje': 'TOKEN NOT FOUND', 'envios': []})
+        responses.add(responses.POST, 'https://testing_host/rekis/api/altaEnvios', status=200,
+                      json={'respuesta': '102', 'mensaje': 'TOKEN NOT FOUND', 'envios': []})
 
         mock_logger = MagicMock()
 

--- a/koiki/tests/test_client.py
+++ b/koiki/tests/test_client.py
@@ -59,7 +59,7 @@ class KoikiTest(TestCase):
             ],
         }
 
-        responses.add(responses.GET, 'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/5',
+        responses.add(responses.GET, 'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/5',
                       status=200,
                       json={
                         "store_email": "detergents@agranel.coop",
@@ -73,7 +73,7 @@ class KoikiTest(TestCase):
                             "state": ""
                         }
                       })
-        responses.add(responses.GET, 'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/6',
+        responses.add(responses.GET, 'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/6',
                       status=200,
                       json={
                         "store_email": "queviure@lazona.coop",

--- a/koiki/tests/test_client.py
+++ b/koiki/tests/test_client.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 from unittest.mock import patch, MagicMock
 import responses
 import json
-import os
 
 from koiki.client import Client
 
@@ -10,8 +9,6 @@ from koiki.client import Client
 class KoikiTest(TestCase):
 
     def setUp(self):
-        os.environ['KOIKI_HOST'] = 'https://testing_host'
-
         self.order = {
             'order_key': 'xxx',
             'customer_note': 'delivery testing',

--- a/koiki/tests/test_create_delivery.py
+++ b/koiki/tests/test_create_delivery.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 import responses
 
 from koiki.create_delivery import CreateDelivery
+import koiki
 
 
 class CreateDeliveryTest(TestCase):
@@ -74,7 +75,7 @@ class CreateDeliveryTest(TestCase):
 
     @responses.activate
     def test_body(self):
-        responses.add(responses.GET, 'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/5',
+        responses.add(responses.GET, f'{koiki.wcfmmp_api_base}/wp-json/wcfmmp/v1/settings/id/5',
                       status=200,
                       json={
                           "store_email": "detergents@agranel.coop",
@@ -89,7 +90,7 @@ class CreateDeliveryTest(TestCase):
                               }
                           })
 
-        responses.add(responses.GET, 'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/6',
+        responses.add(responses.GET, f'{koiki.wcfmmp_api_base}/wp-json/wcfmmp/v1/settings/id/6',
                       status=200,
                       json={
                         "store_email": "queviure@lazona.coop",

--- a/koiki/tests/test_create_delivery.py
+++ b/koiki/tests/test_create_delivery.py
@@ -74,21 +74,22 @@ class CreateDeliveryTest(TestCase):
 
     @responses.activate
     def test_body(self):
-        responses.add(responses.GET, 'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/5',
+        responses.add(responses.GET, 'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/5',
                       status=200,
                       json={
-                        "store_email": "detergents@agranel.coop",
-                        "phone": "93333333",
-                        "address": {
-                            "street_1": "Sant Antoni Maria Claret, 175",
-                            "street_2": "",
-                            "city": "Barcelona",
-                            "zip": "08041",
-                            "country": "",
-                            "state": ""
-                        }
-                      })
-        responses.add(responses.GET, 'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/6',
+                          "store_email": "detergents@agranel.coop",
+                          "phone": "93333333",
+                          "address": {
+                              "street_1": "Sant Antoni Maria Claret, 175",
+                              "street_2": "",
+                              "city": "Barcelona",
+                              "zip": "08041",
+                              "country": "",
+                              "state": ""
+                              }
+                          })
+
+        responses.add(responses.GET, 'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/6',
                       status=200,
                       json={
                         "store_email": "queviure@lazona.coop",

--- a/koiki/tests/test_create_delivery.py
+++ b/koiki/tests/test_create_delivery.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+import responses
 
 from koiki.create_delivery import CreateDelivery
 
@@ -71,7 +72,33 @@ class CreateDeliveryTest(TestCase):
             ]
         }
 
+    @responses.activate
     def test_body(self):
+        responses.add(responses.GET, 'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/5', status=200, json={
+            "store_email": "detergents@agranel.coop",
+            "phone": "93333333",
+            "address": {
+                "street_1": "Sant Antoni Maria Claret, 175",
+                "street_2": "",
+                "city": "Barcelona",
+                "zip": "08041",
+                "country": "",
+                "state": ""
+            }
+        })
+        responses.add(responses.GET, 'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/6', status=200, json={
+            "store_email": "queviure@lazona.coop",
+            "phone": "",
+            "address": {
+                "street_1": "",
+                "street_2": "",
+                "city": "",
+                "zip": "",
+                "country": "ES",
+                "state": ""
+            }
+        })
+
         body = CreateDelivery(self.order).body()
         deliveries = body['envios']
 
@@ -87,13 +114,13 @@ class CreateDeliveryTest(TestCase):
             'nombreRemi': 'A granel',
             'apellidoRemi': '',
             'numeroCalleRemi': '',
-            'direccionRemi': 'C/ La Zona, 1',
-            'codPostalRemi': '08186',
+            'direccionRemi': 'Sant Antoni Maria Claret, 175',
+            'codPostalRemi': '08041',
             'poblacionRemi': 'Barcelona',
-            'provinciaRemi': 'Barcelona',
-            'paisRemi': 'ES',
-            'emailRemi': 'lazona@opcions.org',
-            'telefonoRemi': '518888191'
+            'provinciaRemi': '',
+            'paisRemi': '',
+            'emailRemi': 'detergents@agranel.coop',
+            'telefonoRemi': '93333333'
         }, deliveries[0])
 
         self.assertDictContainsSubset({
@@ -106,13 +133,13 @@ class CreateDeliveryTest(TestCase):
             'nombreRemi': 'Quèviure',
             'apellidoRemi': '',
             'numeroCalleRemi': '',
-            'direccionRemi': 'C/ La Zona, 1',
-            'codPostalRemi': '08186',
-            'poblacionRemi': 'Barcelona',
-            'provinciaRemi': 'Barcelona',
+            'direccionRemi': '',
+            'codPostalRemi': '',
+            'poblacionRemi': '',
+            'provinciaRemi': '',
             'paisRemi': 'ES',
-            'emailRemi': 'lazona@opcions.org',
-            'telefonoRemi': '518888191',
+            'emailRemi': 'queviure@lazona.coop',
+            'telefonoRemi': '',
         }, deliveries[1])
 
     def test_url(self):

--- a/koiki/tests/test_create_delivery.py
+++ b/koiki/tests/test_create_delivery.py
@@ -74,30 +74,34 @@ class CreateDeliveryTest(TestCase):
 
     @responses.activate
     def test_body(self):
-        responses.add(responses.GET, 'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/5', status=200, json={
-            "store_email": "detergents@agranel.coop",
-            "phone": "93333333",
-            "address": {
-                "street_1": "Sant Antoni Maria Claret, 175",
-                "street_2": "",
-                "city": "Barcelona",
-                "zip": "08041",
-                "country": "",
-                "state": ""
-            }
-        })
-        responses.add(responses.GET, 'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/6', status=200, json={
-            "store_email": "queviure@lazona.coop",
-            "phone": "",
-            "address": {
-                "street_1": "",
-                "street_2": "",
-                "city": "",
-                "zip": "",
-                "country": "ES",
-                "state": ""
-            }
-        })
+        responses.add(responses.GET, 'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/5',
+                      status=200,
+                      json={
+                        "store_email": "detergents@agranel.coop",
+                        "phone": "93333333",
+                        "address": {
+                            "street_1": "Sant Antoni Maria Claret, 175",
+                            "street_2": "",
+                            "city": "Barcelona",
+                            "zip": "08041",
+                            "country": "",
+                            "state": ""
+                        }
+                      })
+        responses.add(responses.GET, 'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/6',
+                      status=200,
+                      json={
+                        "store_email": "queviure@lazona.coop",
+                        "phone": "",
+                        "address": {
+                            "street_1": "",
+                            "street_2": "",
+                            "city": "",
+                            "zip": "",
+                            "country": "ES",
+                            "state": ""
+                        }
+                      })
 
         body = CreateDelivery(self.order).body()
         deliveries = body['envios']

--- a/koiki/tests/test_models.py
+++ b/koiki/tests/test_models.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from unittest.mock import MagicMock
 
 from koiki.models import Shipment, Sender, Recipient
 from koiki.woocommerce.models import Vendor, Billing, Shipping
@@ -73,7 +74,18 @@ class ModelsTest(TestCase):
                 "state": "Barcelona"
             }
         })
-        vendor = Vendor(id=1, name='Quèviure', client=fake_client)
+        vendor = Vendor(
+            id=1,
+            name='Quèviure',
+            address='C/ queviure, 1',
+            zip='08080',
+            email='queviure@lazona.coop',
+            country='ES',
+            city='Barcelona',
+            state='Barcelona',
+            phone='+34666554433',
+            client=fake_client
+        )
         sender = Sender(vendor)
 
         self.assertDictEqual(sender.to_dict(), {
@@ -86,7 +98,7 @@ class ModelsTest(TestCase):
             'provinciaRemi': 'Barcelona',
             'paisRemi': 'ES',
             'emailRemi': 'queviure@lazona.coop',
-            'telefonoRemi': '',
+            'telefonoRemi': '+34666554433',
         })
 
     def test_recipient(self):

--- a/koiki/tests/test_models.py
+++ b/koiki/tests/test_models.py
@@ -16,6 +16,7 @@ class FakeResponse():
         else:
             return json.loads(self.body)
 
+
 class FakeClient():
     def __init__(self, resp_body):
         self.resp_body = resp_body

--- a/koiki/tests/test_models.py
+++ b/koiki/tests/test_models.py
@@ -3,6 +3,26 @@ from unittest import TestCase
 from koiki.models import Shipment, Sender, Recipient
 from koiki.woocommerce.models import Vendor, Billing, Shipping
 
+import json
+
+
+class FakeResponse():
+    def __init__(self, body):
+        self.body = body
+
+    def json(self):
+        if isinstance(self.body, dict):
+            return self.body
+        else:
+            return json.loads(self.body)
+
+class FakeClient():
+    def __init__(self, resp_body):
+        self.resp_body = resp_body
+
+    def get(self, _url):
+        return FakeResponse(self.resp_body)
+
 
 class ModelsTest(TestCase):
 
@@ -39,20 +59,33 @@ class ModelsTest(TestCase):
         })
 
     def test_sender(self):
-        vendor = Vendor(id=1, name='Quèviure')
+        fake_client = FakeClient({
+            "store_name": "Quèviure",
+            "store_email": "queviure@lazona.coop",
+            "phone": "",
+            "address": {
+                "street_1": "C/ queviure, 1",
+                "street_2": "",
+                "city": "Barcelona",
+                "zip": "08080",
+                "country": "ES",
+                "state": "Barcelona"
+            }
+        })
+        vendor = Vendor(id=1, name='Quèviure', client=fake_client)
         sender = Sender(vendor)
 
         self.assertDictEqual(sender.to_dict(), {
             'nombreRemi': 'Quèviure',
             'apellidoRemi': '',
-            'direccionRemi': 'C/ La Zona, 1',
+            'direccionRemi': 'C/ queviure, 1',
             'numeroCalleRemi': '',
-            'codPostalRemi': '08186',
+            'codPostalRemi': '08080',
             'poblacionRemi': 'Barcelona',
             'provinciaRemi': 'Barcelona',
             'paisRemi': 'ES',
-            'emailRemi': 'lazona@opcions.org',
-            'telefonoRemi': '518888191',
+            'emailRemi': 'queviure@lazona.coop',
+            'telefonoRemi': '',
         })
 
     def test_recipient(self):

--- a/koiki/tests/test_models.py
+++ b/koiki/tests/test_models.py
@@ -7,25 +7,6 @@ from koiki.woocommerce.models import Vendor, Billing, Shipping
 import json
 
 
-class FakeResponse():
-    def __init__(self, body):
-        self.body = body
-
-    def json(self):
-        if isinstance(self.body, dict):
-            return self.body
-        else:
-            return json.loads(self.body)
-
-
-class FakeClient():
-    def __init__(self, resp_body):
-        self.resp_body = resp_body
-
-    def get(self, _url):
-        return FakeResponse(self.resp_body)
-
-
 class ModelsTest(TestCase):
 
     maxDiff = None
@@ -61,19 +42,6 @@ class ModelsTest(TestCase):
         })
 
     def test_sender(self):
-        fake_client = FakeClient({
-            "store_name": "Quèviure",
-            "store_email": "queviure@lazona.coop",
-            "phone": "",
-            "address": {
-                "street_1": "C/ queviure, 1",
-                "street_2": "",
-                "city": "Barcelona",
-                "zip": "08080",
-                "country": "ES",
-                "state": "Barcelona"
-            }
-        })
         vendor = Vendor(
             id=1,
             name='Quèviure',
@@ -83,8 +51,7 @@ class ModelsTest(TestCase):
             country='ES',
             city='Barcelona',
             state='Barcelona',
-            phone='+34666554433',
-            client=fake_client
+            phone='+34666554433'
         )
         sender = Sender(vendor)
 

--- a/koiki/tests/test_models.py
+++ b/koiki/tests/test_models.py
@@ -1,10 +1,7 @@
 from unittest import TestCase
-from unittest.mock import MagicMock
 
 from koiki.models import Shipment, Sender, Recipient
 from koiki.woocommerce.models import Vendor, Billing, Shipping
-
-import json
 
 
 class ModelsTest(TestCase):

--- a/koiki/tests/test_wcfmmp.py
+++ b/koiki/tests/test_wcfmmp.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from koiki.woocommerce.wcfmmp import APIClient
+
+
+class APIClientTest(TestCase):
+
+    def setUp(self):
+        self.mock_client = MagicMock()
+
+    def test_request(self):
+        self.mock_client.get = MagicMock()
+
+        api_client = APIClient(self.mock_client)
+        api_client.request('endpoint')
+
+        self.mock_client.get.assert_called_once_with(
+                'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/endpoint')
+
+    @patch('koiki.woocommerce.wcfmmp.logging', autospec=True)
+    def test_request_logging(self, mock_logger):
+        api_client = APIClient(self.mock_client, mock_logger)
+        api_client.request('endpoint')
+
+        mock_logger.info.assert_called_once_with(
+            'Wcfmpp request. url=http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/endpoint')

--- a/koiki/tests/test_wcfmmp.py
+++ b/koiki/tests/test_wcfmmp.py
@@ -16,7 +16,7 @@ class APIClientTest(TestCase):
         api_client.request('endpoint')
 
         self.mock_client.get.assert_called_once_with(
-                'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/endpoint')
+                'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/endpoint')
 
     @patch('koiki.woocommerce.wcfmmp.logging', autospec=True)
     def test_request_logging(self, mock_logger):
@@ -24,4 +24,4 @@ class APIClientTest(TestCase):
         api_client.request('endpoint')
 
         mock_logger.info.assert_called_once_with(
-            'Wcfmpp request. url=https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/endpoint')
+            'Wcfmpp request. url=https://wcfmmp_testing_host/wp-json/wcfmmp/v1/endpoint')

--- a/koiki/tests/test_wcfmmp.py
+++ b/koiki/tests/test_wcfmmp.py
@@ -16,7 +16,7 @@ class APIClientTest(TestCase):
         api_client.request('endpoint')
 
         self.mock_client.get.assert_called_once_with(
-                'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/endpoint')
+                'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/endpoint')
 
     @patch('koiki.woocommerce.wcfmmp.logging', autospec=True)
     def test_request_logging(self, mock_logger):
@@ -24,4 +24,4 @@ class APIClientTest(TestCase):
         api_client.request('endpoint')
 
         mock_logger.info.assert_called_once_with(
-            'Wcfmpp request. url=http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/endpoint')
+            'Wcfmpp request. url=https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/endpoint')

--- a/koiki/tests/test_woocommerce_models.py
+++ b/koiki/tests/test_woocommerce_models.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-from unittest.mock import patch
 import httpretty
 import json
 

--- a/koiki/tests/test_woocommerce_models.py
+++ b/koiki/tests/test_woocommerce_models.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from unittest.mock import patch, MagicMock
 import httpretty
 import json
 
@@ -48,7 +49,8 @@ class WooocommerceModelsTest(TestCase):
         self.assertEquals(vendor.id, 1)
         self.assertEquals(vendor.name, 'name')
 
-    def test_vendor_get(self):
+    @patch('koiki.woocommerce.models.logging', autospec=True)
+    def test_vendor_get(self, mock_logger):
         httpretty.register_uri(
             httpretty.GET,
             'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/1',
@@ -67,11 +69,16 @@ class WooocommerceModelsTest(TestCase):
                 }
             })
         )
-        vendor = Vendor(1, 'name')
+
+        mock_logger = MagicMock()
+        vendor = Vendor(1, 'name', logger=mock_logger)
         vendor.get()
 
         self.assertEquals(vendor.address, "Passeig de Gràcia 1")
         self.assertEquals(vendor.zip, "08092")
+
+        mock_logger.info.assert_called_once_with(
+            'Wcfmpp request. url=http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/1')
 
     def test_shipping(self):
         data = {

--- a/koiki/tests/test_woocommerce_models.py
+++ b/koiki/tests/test_woocommerce_models.py
@@ -52,7 +52,7 @@ class WooocommerceModelsTest(TestCase):
     def test_vendor_get(self):
         httpretty.register_uri(
             httpretty.GET,
-            'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/1',
+            'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/1',
             status=200,
             content_type='application/json',
             body=json.dumps({

--- a/koiki/tests/test_woocommerce_models.py
+++ b/koiki/tests/test_woocommerce_models.py
@@ -3,6 +3,7 @@ import httpretty
 import json
 
 from koiki.woocommerce.models import LineItem, Vendor, Shipping, Billing
+import koiki
 
 
 class WooocommerceModelsTest(TestCase):
@@ -51,7 +52,7 @@ class WooocommerceModelsTest(TestCase):
     def test_vendor_fetch(self):
         httpretty.register_uri(
             httpretty.GET,
-            'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/1',
+            f'{koiki.wcfmmp_api_base}/wp-json/wcfmmp/v1/settings/id/1',
             status=200,
             content_type='application/json',
             body=json.dumps({

--- a/koiki/tests/test_woocommerce_models.py
+++ b/koiki/tests/test_woocommerce_models.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 import httpretty
 import json
 
@@ -49,8 +49,7 @@ class WooocommerceModelsTest(TestCase):
         self.assertEquals(vendor.id, 1)
         self.assertEquals(vendor.name, 'name')
 
-    @patch('koiki.woocommerce.models.logging', autospec=True)
-    def test_vendor_get(self, mock_logger):
+    def test_vendor_get(self):
         httpretty.register_uri(
             httpretty.GET,
             'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/1',
@@ -70,15 +69,11 @@ class WooocommerceModelsTest(TestCase):
             })
         )
 
-        mock_logger = MagicMock()
-        vendor = Vendor(1, 'name', logger=mock_logger)
+        vendor = Vendor(1, 'name')
         vendor.get()
 
         self.assertEquals(vendor.address, "Passeig de Gràcia 1")
         self.assertEquals(vendor.zip, "08092")
-
-        mock_logger.info.assert_called_once_with(
-            'Wcfmpp request. url=http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/1')
 
     def test_shipping(self):
         data = {

--- a/koiki/tests/test_woocommerce_models.py
+++ b/koiki/tests/test_woocommerce_models.py
@@ -48,7 +48,7 @@ class WooocommerceModelsTest(TestCase):
         self.assertEquals(vendor.id, 1)
         self.assertEquals(vendor.name, 'name')
 
-    def test_vendor_get(self):
+    def test_vendor_fetch(self):
         httpretty.register_uri(
             httpretty.GET,
             'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/1',
@@ -69,7 +69,7 @@ class WooocommerceModelsTest(TestCase):
         )
 
         vendor = Vendor(id=1, name='name')
-        vendor.get()
+        vendor.fetch()
 
         self.assertEquals(vendor.address, "Passeig de Gràcia 1")
         self.assertEquals(vendor.zip, "08092")

--- a/koiki/tests/test_woocommerce_models.py
+++ b/koiki/tests/test_woocommerce_models.py
@@ -33,7 +33,7 @@ class WooocommerceModelsTest(TestCase):
         line_item = LineItem(line_item)
 
         self.assertEquals(line_item.quantity, 3)
-        self.assertEquals(line_item.vendor, Vendor('5', 'A granel'))
+        self.assertEquals(line_item.vendor, Vendor(id='5', name='A granel'))
 
     def test_line_item_without_vendor(self):
         data = {
@@ -44,7 +44,7 @@ class WooocommerceModelsTest(TestCase):
         self.assertRaises(Exception, LineItem, data)
 
     def test_vendor(self):
-        vendor = Vendor(1, 'name')
+        vendor = Vendor(id=1, name='name')
 
         self.assertEquals(vendor.id, 1)
         self.assertEquals(vendor.name, 'name')
@@ -69,7 +69,7 @@ class WooocommerceModelsTest(TestCase):
             })
         )
 
-        vendor = Vendor(1, 'name')
+        vendor = Vendor(id=1, name='name')
         vendor.get()
 
         self.assertEquals(vendor.address, "Passeig de Gràcia 1")

--- a/koiki/tests/test_woocommerce_models.py
+++ b/koiki/tests/test_woocommerce_models.py
@@ -1,4 +1,6 @@
 from unittest import TestCase
+import httpretty
+import json
 
 from koiki.woocommerce.models import LineItem, Vendor, Shipping, Billing
 
@@ -45,6 +47,31 @@ class WooocommerceModelsTest(TestCase):
 
         self.assertEquals(vendor.id, 1)
         self.assertEquals(vendor.name, 'name')
+
+    def test_vendor_get(self):
+        httpretty.register_uri(
+            httpretty.GET,
+            'http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/1',
+            status=200,
+            content_type='application/json',
+            body=json.dumps({
+                "store_email": "store@example.com",
+                "phone": "+34666554433",
+                "address": {
+                    "street_1": "Passeig de Gràcia 1",
+                    "street_2": "",
+                    "city": "Barcelona",
+                    "zip": "08092",
+                    "country": "ES",
+                    "state": "Barcelona"
+                }
+            })
+        )
+        vendor = Vendor(1, 'name')
+        vendor.get()
+
+        self.assertEquals(vendor.address, "Passeig de Gràcia 1")
+        self.assertEquals(vendor.zip, "08092")
 
     def test_shipping(self):
         data = {

--- a/koiki/woocommerce/models.py
+++ b/koiki/woocommerce/models.py
@@ -28,7 +28,7 @@ class Vendor():
         self.email = email
         self.phone = phone
 
-    def get(self):
+    def fetch(self):
         response = self.client.request(f"settings/id/{self.id}")
         self._convert_to_resource(response)
         return self

--- a/koiki/woocommerce/models.py
+++ b/koiki/woocommerce/models.py
@@ -1,23 +1,6 @@
+from koiki.woocommerce.wcfmmp import APIClient
+
 import re
-import requests
-import logging
-
-
-class APIClient():
-    API_PATH = "wp-json/wcfmmp/v1"
-    PATH = "settings"
-
-    def __init__(self, logger):
-        self.client = requests
-        api_base = "http://staging.lazona.coop"
-        self.api_url = f'{api_base}/{self.API_PATH}'
-        self.logger = logger
-
-    def request(self, url):
-        abs_url = f'{self.api_url}/{self.PATH}/{url}'
-        self.logger.info(f'Wcfmpp request. url={abs_url}')
-
-        return self.client.get(abs_url)
 
 
 class Vendor():
@@ -31,11 +14,9 @@ class Vendor():
         state=None,
         country=None,
         email=None,
-        phone=None,
-        client=requests,
-        logger=logging.getLogger('django.server')
+        phone=None
     ):
-        self.client = APIClient(logger)
+        self.client = APIClient()
 
         self.id = id
         self.name = name

--- a/koiki/woocommerce/models.py
+++ b/koiki/woocommerce/models.py
@@ -3,33 +3,54 @@ import requests
 import logging
 
 
-class Vendor():
-    API_URL = "http://staging.lazona.coop/wp-json/wcfmmp/v1"
+class APIClient():
+    API_PATH = "wp-json/wcfmmp/v1"
     PATH = "settings"
 
-    def __init__(self, id, name, client=requests, logger=logging.getLogger('django.server')):
-        self.client = client
+    def __init__(self, logger):
+        self.client = requests
+        api_base = "http://staging.lazona.coop"
+        self.api_url = f'{api_base}/{self.API_PATH}'
         self.logger = logger
+
+    def request(self, url):
+        abs_url = f'{self.api_url}/{self.PATH}/{url}'
+        self.logger.info(f'Wcfmpp request. url={abs_url}')
+
+        return self.client.get(abs_url)
+
+
+class Vendor():
+    def __init__(
+        self,
+        id,
+        name,
+        address=None,
+        zip=None,
+        city=None,
+        state=None,
+        country=None,
+        email=None,
+        phone=None,
+        client=requests,
+        logger=logging.getLogger('django.server')
+    ):
+        self.client = APIClient(logger)
 
         self.id = id
         self.name = name
-        self.address = None
-        self.zip = None
-        self.city = None
-        self.state = None
-        self.country = None
-        self.email = None
-        self.phone = None
+        self.address = address
+        self.zip = zip
+        self.city = city
+        self.state = state
+        self.country = country
+        self.email = email
+        self.phone = phone
 
     def get(self):
-        response = self._request(f"id/{self.id}")
+        response = self.client.request(f"id/{self.id}")
         self._convert_to_resource(response)
         return self
-
-    def _request(self, url):
-        abs_url = f'{self.API_URL}/{self.PATH}/{url}'
-        self.logger.info(f'Wcfmpp request. url={abs_url}')
-        return self.client.get(abs_url)
 
     def _convert_to_resource(self, response):
         body = response.json()

--- a/koiki/woocommerce/models.py
+++ b/koiki/woocommerce/models.py
@@ -56,7 +56,7 @@ class LineItem():
         self.quantity = line_item['quantity']
         self.metadata = line_item['meta_data']
         vendor = self._find_vendor()
-        self.vendor = Vendor(vendor[0], vendor[1])
+        self.vendor = Vendor(id=vendor[0], name=vendor[1])
 
     # Finds the vendor attributes from all the metadata entries
     def _find_vendor(self):

--- a/koiki/woocommerce/models.py
+++ b/koiki/woocommerce/models.py
@@ -29,7 +29,7 @@ class Vendor():
         self.phone = phone
 
     def get(self):
-        response = self.client.request(f"id/{self.id}")
+        response = self.client.request(f"settings/id/{self.id}")
         self._convert_to_resource(response)
         return self
 

--- a/koiki/woocommerce/models.py
+++ b/koiki/woocommerce/models.py
@@ -1,13 +1,16 @@
 import re
 import requests
+import logging
 
 
 class Vendor():
-    BASE_URL = "http://staging.lazona.coop/wp-json/wcfmmp/v1"
+    API_URL = "http://staging.lazona.coop/wp-json/wcfmmp/v1"
     PATH = "settings"
 
-    def __init__(self, id, name, client=requests):
+    def __init__(self, id, name, client=requests, logger=logging.getLogger('django.server')):
         self.client = client
+        self.logger = logger
+
         self.id = id
         self.name = name
         self.address = None
@@ -24,7 +27,9 @@ class Vendor():
         return self
 
     def _request(self, url):
-        return self.client.get(f'{self.BASE_URL}/{self.PATH}/{url}')
+        abs_url = f'{self.API_URL}/{self.PATH}/{url}'
+        self.logger.info(f'Wcfmpp request. url={abs_url}')
+        return self.client.get(abs_url)
 
     def _convert_to_resource(self, response):
         body = response.json()

--- a/koiki/woocommerce/models.py
+++ b/koiki/woocommerce/models.py
@@ -1,10 +1,41 @@
 import re
+import requests
 
 
 class Vendor():
-    def __init__(self, id, name):
+    BASE_URL = "http://staging.lazona.coop/wp-json/wcfmmp/v1"
+    PATH = "settings"
+
+    def __init__(self, id, name, client=requests):
+        self.client = client
         self.id = id
         self.name = name
+        self.address = None
+        self.zip = None
+        self.city = None
+        self.state = None
+        self.country = None
+        self.email = None
+        self.phone = None
+
+    def get(self):
+        response = self._request(f"id/{self.id}")
+        self._convert_to_resource(response)
+        return self
+
+    def _request(self, url):
+        return self.client.get(f'{self.BASE_URL}/{self.PATH}/{url}')
+
+    def _convert_to_resource(self, response):
+        body = response.json()
+
+        self.address = body['address']['street_1']
+        self.zip = body['address']['zip']
+        self.city = body['address']['city']
+        self.state = body['address']['state']
+        self.country = body['address']['country']
+        self.email = body['store_email']
+        self.phone = body['phone']
 
     def __eq__(self, other):
         if not isinstance(other, Vendor):

--- a/koiki/woocommerce/wcfmmp.py
+++ b/koiki/woocommerce/wcfmmp.py
@@ -6,7 +6,6 @@ import koiki
 
 class APIClient():
     API_PATH = "wp-json/wcfmmp/v1"
-    PATH = "settings"
 
     def __init__(self, client=requests, logger=logging.getLogger('django.server')):
         self.client = client
@@ -14,8 +13,8 @@ class APIClient():
         self.api_url = f'{api_base}/{self.API_PATH}'
         self.logger = logger
 
-    def request(self, url):
-        abs_url = f'{self.api_url}/{self.PATH}/{url}'
+    def request(self, path):
+        abs_url = f'{self.api_url}/{path}'
         self.logger.info(f'Wcfmpp request. url={abs_url}')
 
         return self.client.get(abs_url)

--- a/koiki/woocommerce/wcfmmp.py
+++ b/koiki/woocommerce/wcfmmp.py
@@ -1,6 +1,8 @@
 import requests
 import logging
 
+import koiki
+
 
 class APIClient():
     API_PATH = "wp-json/wcfmmp/v1"
@@ -8,7 +10,7 @@ class APIClient():
 
     def __init__(self, client=requests, logger=logging.getLogger('django.server')):
         self.client = client
-        api_base = "http://staging.lazona.coop"
+        api_base = koiki.wcfmmp_api_base
         self.api_url = f'{api_base}/{self.API_PATH}'
         self.logger = logger
 

--- a/koiki/woocommerce/wcfmmp.py
+++ b/koiki/woocommerce/wcfmmp.py
@@ -1,0 +1,19 @@
+import requests
+import logging
+
+
+class APIClient():
+    API_PATH = "wp-json/wcfmmp/v1"
+    PATH = "settings"
+
+    def __init__(self, client=requests, logger=logging.getLogger('django.server')):
+        self.client = client
+        api_base = "http://staging.lazona.coop"
+        self.api_url = f'{api_base}/{self.API_PATH}'
+        self.logger = logger
+
+    def request(self, url):
+        abs_url = f'{self.api_url}/{self.PATH}/{url}'
+        self.logger.info(f'Wcfmpp request. url={abs_url}')
+
+        return self.client.get(abs_url)


### PR DESCRIPTION
This makes the integration fetch all the vendor details from the WCFM Marketplace's API (this the Woocommerce's Marketplace plugin we're using) as the sender's details to Koiki. That is, the details where the order needs to be picked up from.

We do so by calling `vendor.get()` right before creating the request body to be sent to Koiki's API. That's why I implemented an APIClient for WCFM which will use more and more.

This extra request makes it a must to start working on Celery ASAP so all this communication between APIs happens asynchronously. Now, it's very likely that WP (the webhook that triggers it all) will kill the request due to timeout.

While at it, I also DRYied and decoupled configuration settings from the tests and the classes using them and moved them to `__init__.py` files. I draw this inspiration from https://github.com/stripe/stripe-python/blob/e70949b8b6961907620f01aaea60ecea9759558f/stripe/__init__.py#L14-L28.