### PR TITLE
Silence logging in testing

### DIFF
--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -1,4 +1,5 @@
 import httpretty
+import logging
 
 import koiki
 
@@ -6,3 +7,4 @@ httpretty.enable(allow_net_connect=False)
 
 koiki.host = 'https://testing_host'
 koiki.wcfmmp_host = 'https://wcfmmp_testing_host'
+koiki.logger = logging.getLogger('django.tests')

--- a/koiki/__init__.py
+++ b/koiki/__init__.py
@@ -1,4 +1,6 @@
 import os
+import logging
 
 host = os.getenv('KOIKI_HOST')
 wcfmmp_api_base = os.getenv('WCFMMP_API_BASE')
+logger = logging.getLogger('django.server')

--- a/koiki/client.py
+++ b/koiki/client.py
@@ -1,5 +1,4 @@
 import requests
-import logging
 import os
 import json
 import copy
@@ -15,8 +14,7 @@ API_PATH = '/rekis/api'
 
 class Client():
 
-    def __init__(self, order, auth_token=os.getenv('KOIKI_AUTH_TOKEN'),
-                 logger=logging.getLogger('django.server')):
+    def __init__(self, order, auth_token=os.getenv('KOIKI_AUTH_TOKEN'), logger=koiki.logger):
         self.order = order
         self.auth_token = auth_token
         self.host = koiki.host

--- a/koiki/client.py
+++ b/koiki/client.py
@@ -31,7 +31,7 @@ class Client():
         response_body = json.loads(response.text)
 
         if self._is_errored(response_body):
-            self._log(response.status_code, response.text, logger='error')
+            self._log(response.status_code, response.text, level='error')
             return Error(response_body)
         else:
             self._log(response.status_code, self._masked_body(response_body))
@@ -54,9 +54,10 @@ class Client():
     def _is_errored(self, response_body):
         return response_body.get('respuesta', '') != '101'
 
-    def _log(self, code, msg, logger='info'):
+    def _log(self, code, msg, level='info'):
         log_line = "Koiki response. status={}, body={}".format(code, msg)
-        if logger == 'info':
+
+        if level == 'info':
             self.logger.info(log_line)
         else:
             self.logger.error(log_line)

--- a/koiki/tests/__init__.py
+++ b/koiki/tests/__init__.py
@@ -1,4 +1,5 @@
 import httpretty
+import logging
 
 import koiki
 
@@ -6,3 +7,4 @@ httpretty.enable(allow_net_connect=False)
 
 koiki.host = 'https://testing_host'
 koiki.wcfmmp_host = 'https://wcfmmp_testing_host'
+koiki.logger = logging.getLogger('django.tests')

--- a/koiki/tests/test_client.py
+++ b/koiki/tests/test_client.py
@@ -73,7 +73,7 @@ class KoikiTest(TestCase):
                       })
 
     @responses.activate
-    @patch('koiki.client.logging', autospec=True)
+    @patch('koiki.logger', autospec=True)
     def test_create_delivery_successful_response(self, mock_logger):
         responses.add(responses.POST, 'https://testing_host/rekis/api/altaEnvios', status=200,
                       json={
@@ -88,7 +88,7 @@ class KoikiTest(TestCase):
         self.assertEqual(delivery.to_dict(), {'number': '123', 'barcode': 'yyy', 'label': 'abcd'})
 
     @responses.activate
-    @patch('koiki.client.logging', autospec=True)
+    @patch('koiki.logger', autospec=True)
     def test_create_delivery_failed_response(self, mock_logger):
         responses.add(responses.POST, 'https://testing_host/rekis/api/altaEnvios', status=400,
                       json={'error': 'Bad Request'})
@@ -116,7 +116,7 @@ class KoikiTest(TestCase):
         self.assertEqual(delivery.to_dict(), {'error': 'TOKEN NOT FOUND'})
 
     @responses.activate
-    @patch('koiki.client.logging', autospec=True)
+    @patch('koiki.logger', autospec=True)
     @patch('koiki.client.requests.post', autospec=True)
     def test_create_delivery_sends_request(self, post_mock, _logger_mock):
         response = MagicMock()

--- a/koiki/tests/test_wcfmmp.py
+++ b/koiki/tests/test_wcfmmp.py
@@ -18,7 +18,7 @@ class APIClientTest(TestCase):
         self.mock_client.get.assert_called_once_with(
                 'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/endpoint')
 
-    @patch('koiki.woocommerce.wcfmmp.logging', autospec=True)
+    @patch('koiki.logger', autospec=True)
     def test_request_logging(self, mock_logger):
         api_client = APIClient(self.mock_client, mock_logger)
         api_client.request('endpoint')

--- a/koiki/woocommerce/wcfmmp.py
+++ b/koiki/woocommerce/wcfmmp.py
@@ -1,5 +1,4 @@
 import requests
-import logging
 
 import koiki
 
@@ -8,7 +7,7 @@ class APIClient():
     api_path = "wp-json/wcfmmp/v1"
     api_url = f'{koiki.wcfmmp_host}/{api_path}'
 
-    def __init__(self, client=requests, logger=logging.getLogger('django.server')):
+    def __init__(self, client=requests, logger=koiki.logger):
         self.client = client
         self.logger = logger
 

--- a/lazona_connector/settings.py
+++ b/lazona_connector/settings.py
@@ -28,6 +28,24 @@ DEBUG = os.environ.get('DJANGO_DEBUG', '') != 'False'
 
 ALLOWED_HOSTS = ["lazona-connector-staging.herokuapp.com", "127.0.0.1", ".ngrok.io"]
 
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'null': {
+            'level': 'INFO',
+            'class': 'logging.NullHandler',
+        },
+    },
+    'loggers': {
+        'django.tests': {
+            'handlers': ['null'],
+            'level': 'INFO',
+            'propagate': False,
+        }
+    }
+}
+
 
 # Application definition
 


### PR DESCRIPTION
This will silence all log messages by default. Things are getting very noisy. In any case, you can always remove this config when debugging tests.

This makes use of `LOGGING` which gets merged with Django's default logging settings. See https://docs.djangoproject.com/en/3.2/topics/logging/#configuring-logging.

It gets use from

```
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.......[03/May/2021 14:31:45,445] Wcfmpp request. url=https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/6
[03/May/2021 14:31:45,461] Koiki request to https://testing_host/rekis/api/altaEnvios. body={'formatoEtiqueta': 'PDF', 'envios': [{'numPedido': 'xxx', 'bultos': 1, 'kilos': 0.0, 'tipoServicio': '', 'reembolso': 0.0, 'observaciones': '', 'nombreDesti': 'John', 'apellidoDesti': 'Lennon', 'direccionDesti': 'Beatles Street 66', 'direccionAdicionalDesti': '', 'numeroCalleDesti': '', 'codPostalDesti': '08032', 'poblacionDesti': 'Barcelona', 'provinciaDesti': 'Barcelona', 'paisDesti': 'ES', 'telefonoDesti': '666666666', 'emailDesti': 'lennon@example.com', 'nombreRemi': 'Quèviure', 'apellidoRemi': '', 'numeroCalleRemi': '', 'direccionRemi': '', 'codPostalRemi': '', 'poblacionRemi': '', 'provinciaRemi': '', 'paisRemi': 'ES', 'emailRemi': 'queviure@lazona.coop', 'telefonoRemi': ''}], 'token': '4c615f32-8fc3-46a5-b41b-0acf5436aa3a'}
[03/May/2021 14:31:45,471] Koiki response. status=200, body={"message": "HTTPretty :)"}
....[03/May/2021 14:31:45,849] Wcfmpp request. url=https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/6
.[03/May/2021 14:31:45,874] Wcfmpp request. url=https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/6
[03/May/2021 14:31:45,876] Koiki request to https://testing_host/rekis/api/altaEnvios. body={'formatoEtiqueta': 'PDF', 'envios': [{'numPedido': 'xxx', 'bultos': 1, 'kilos': 0.0, 'tipoServicio': '', 'reembolso': 0.0, 'observaciones': 'delivery testing', 'nombreDesti': 'James', 'apellidoDesti': 'Bond', 'direccionDesti': 'Address 1', 'direccionAdicionalDesti': 'address 2', 'numeroCalleDesti': '', 'codPostalDesti': '08025', 'poblacionDesti': 'Barcelona', 'provinciaDesti': 'Barcelona', 'paisDesti': 'ES', 'telefonoDesti': '666554433', 'emailDesti': 'email@example.com', 'nombreRemi': 'Quèviure', 'apellidoRemi': '', 'numeroCalleRemi': '', 'direccionRemi': '', 'codPostalRemi': '', 'poblacionRemi': '', 'provinciaRemi': '', 'paisRemi': 'ES', 'emailRemi': 'queviure@lazona.coop', 'telefonoRemi': ''}], 'token': 'xxx'}
[03/May/2021 14:31:45,876] Koiki response. status=200, body={'respuesta': '101', 'mensaje': 'OK', 'envios': [{'numPedido': '123', 'codBarras': 'yyy', 'etiqueta': 'abcd...'}]}
.[03/May/2021 14:31:45,876] Wcfmpp request. url=https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/6
.[03/May/2021 14:31:45,912] Wcfmpp request. url=https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/6
[03/May/2021 14:31:45,914] Koiki request to https://testing_host/rekis/api/altaEnvios. body={'formatoEtiqueta': 'PDF', 'envios': [{'numPedido': 'xxx', 'bultos': 1, 'kilos': 0.0, 'tipoServicio': '', 'reembolso': 0.0, 'observaciones': 'delivery testing', 'nombreDesti': 'James', 'apellidoDesti': 'Bond', 'direccionDesti': 'Address 1', 'direccionAdicionalDesti': 'address 2', 'numeroCalleDesti': '', 'codPostalDesti': '08025', 'poblacionDesti': 'Barcelona', 'provinciaDesti': 'Barcelona', 'paisDesti': 'ES', 'telefonoDesti': '666554433', 'emailDesti': 'email@example.com', 'nombreRemi': 'Quèviure', 'apellidoRemi': '', 'numeroCalleRemi': '', 'direccionRemi': '', 'codPostalRemi': '', 'poblacionRemi': '', 'provinciaRemi': '', 'paisRemi': 'ES', 'emailRemi': 'queviure@lazona.coop', 'telefonoRemi': ''}], 'token': '4c615f32-8fc3-46a5-b41b-0acf5436aa3a'}
[03/May/2021 14:31:45,916] Koiki response. status=200, body={'respuesta': '101', 'mensaje': 'OK', 'envios': [{'numPedido': '123', 'codBarras': 'yyy', 'etiqueta': 'abcd...'}]}
.[03/May/2021 14:31:45,916] Wcfmpp request. url=https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/5
[03/May/2021 14:31:45,918] Wcfmpp request. url=https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/6
.......[03/May/2021 14:31:45,920] Wcfmpp request. url=https://wcfmmp_testing_host/wp-json/wcfmmp/v1/endpoint
........[03/May/2021 14:31:45,952] Wcfmpp request. url=https://wcfmmp_testing_host/wp-json/wcfmmp/v1/settings/id/1
.
----------------------------------------------------------------------
Ran 31 tests in 0.685s

OK
Destroying test database for alias 'default'...
```

to

```
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
...............................
----------------------------------------------------------------------
Ran 31 tests in 0.439s

OK
Destroying test database for alias 'default'...
```