### PR TITLE
Read AUTH_TOKEN from config in __init__

### DIFF
--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -8,3 +8,4 @@ httpretty.enable(allow_net_connect=False)
 koiki.host = 'https://testing_host'
 koiki.wcfmmp_host = 'https://wcfmmp_testing_host'
 koiki.logger = logging.getLogger('django.tests')
+koiki.auth_token = 'testing_auth_token'

--- a/koiki/__init__.py
+++ b/koiki/__init__.py
@@ -4,3 +4,4 @@ import logging
 host = os.getenv('KOIKI_HOST')
 wcfmmp_host = os.getenv('WCFMMP_API_BASE')
 logger = logging.getLogger('django.server')
+auth_token = os.getenv('KOIKI_AUTH_TOKEN')

--- a/koiki/client.py
+++ b/koiki/client.py
@@ -1,5 +1,4 @@
 import requests
-import os
 import json
 import copy
 
@@ -14,7 +13,7 @@ API_PATH = '/rekis/api'
 
 class Client():
 
-    def __init__(self, order, auth_token=os.getenv('KOIKI_AUTH_TOKEN'), logger=koiki.logger):
+    def __init__(self, order, auth_token=koiki.auth_token, logger=koiki.logger):
         self.order = order
         self.auth_token = auth_token
         self.host = koiki.host

--- a/koiki/tests/__init__.py
+++ b/koiki/tests/__init__.py
@@ -8,3 +8,4 @@ httpretty.enable(allow_net_connect=False)
 koiki.host = 'https://testing_host'
 koiki.wcfmmp_host = 'https://wcfmmp_testing_host'
 koiki.logger = logging.getLogger('django.tests')
+koiki.auth_token = 'testing_auth_token'


### PR DESCRIPTION
This is the last missing piece of config that wasn't in __init__ yet. We finally decoupled Koiki's API client from these config details and things are a bit more changeable.