### PR TITLE
Authenticate wcfmmp requests

### DIFF
--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -6,6 +6,10 @@ import koiki
 httpretty.enable(allow_net_connect=False)
 
 koiki.host = 'https://testing_host'
+
 koiki.wcfmmp_host = 'https://wcfmmp_testing_host'
+koiki.wcfmmp_user = 'test_wcfmmp_user'
+koiki.wcfmmp_password = 'test_wcfmmp_password'
+
 koiki.logger = logging.getLogger('django.tests')
 koiki.auth_token = 'testing_auth_token'

--- a/koiki/__init__.py
+++ b/koiki/__init__.py
@@ -2,6 +2,10 @@ import os
 import logging
 
 host = os.getenv('KOIKI_HOST')
+
 wcfmmp_host = os.getenv('WCFMMP_HOST')
+wcfmmp_user = os.getenv('WCFMMP_USER')
+wcfmmp_password = os.getenv('WCFMMP_PASSWORD')
+
 logger = logging.getLogger('django.server')
 auth_token = os.getenv('KOIKI_AUTH_TOKEN')

--- a/koiki/tests/__init__.py
+++ b/koiki/tests/__init__.py
@@ -6,6 +6,10 @@ import koiki
 httpretty.enable(allow_net_connect=False)
 
 koiki.host = 'https://testing_host'
+
 koiki.wcfmmp_host = 'https://wcfmmp_testing_host'
+koiki.wcfmmp_user = 'test_wcfmmp_user'
+koiki.wcfmmp_password = 'test_wcfmmp_password'
+
 koiki.logger = logging.getLogger('django.tests')
 koiki.auth_token = 'testing_auth_token'

--- a/koiki/tests/test_wcfmmp.py
+++ b/koiki/tests/test_wcfmmp.py
@@ -16,7 +16,9 @@ class APIClientTest(TestCase):
         api_client.request('endpoint')
 
         self.mock_client.get.assert_called_once_with(
-                'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/endpoint')
+            'https://wcfmmp_testing_host/wp-json/wcfmmp/v1/endpoint',
+            auth=('test_wcfmmp_user', 'test_wcfmmp_password')
+        )
 
     @patch('koiki.logger', autospec=True)
     def test_request_logging(self, mock_logger):

--- a/koiki/tests/test_wcfmmp.py
+++ b/koiki/tests/test_wcfmmp.py
@@ -25,3 +25,13 @@ class APIClientTest(TestCase):
 
         mock_logger.info.assert_called_once_with(
             'Wcfmpp request. url=https://wcfmmp_testing_host/wp-json/wcfmmp/v1/endpoint')
+
+    def test_failed_request(self):
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        self.mock_client.get.return_value = mock_response
+
+        api_client = APIClient(self.mock_client)
+        api_client.request('endpoint')
+
+        mock_response.raise_for_status.assert_called_once()

--- a/koiki/woocommerce/wcfmmp.py
+++ b/koiki/woocommerce/wcfmmp.py
@@ -15,4 +15,6 @@ class APIClient():
         abs_url = f'{self.api_url}/{path}'
         self.logger.info(f'Wcfmpp request. url={abs_url}')
 
-        return self.client.get(abs_url)
+        response = self.client.get(abs_url)
+        response.raise_for_status()
+        return response

--- a/koiki/woocommerce/wcfmmp.py
+++ b/koiki/woocommerce/wcfmmp.py
@@ -15,6 +15,7 @@ class APIClient():
         abs_url = f'{self.api_url}/{path}'
         self.logger.info(f'Wcfmpp request. url={abs_url}')
 
-        response = self.client.get(abs_url)
+        response = self.client.get(abs_url, auth=(koiki.wcfmmp_user, koiki.wcfmmp_password))
         response.raise_for_status()
+
         return response

--- a/koiki/woocommerce/wcfmmp.py
+++ b/koiki/woocommerce/wcfmmp.py
@@ -10,12 +10,14 @@ class APIClient():
     def __init__(self, client=requests, logger=koiki.logger):
         self.client = client
         self.logger = logger
+        self.user = koiki.wcfmmp_user
+        self.password = koiki.wcfmmp_password
 
     def request(self, path):
         abs_url = f'{self.api_url}/{path}'
         self.logger.info(f'Wcfmpp request. url={abs_url}')
 
-        response = self.client.get(abs_url, auth=(koiki.wcfmmp_user, koiki.wcfmmp_password))
+        response = self.client.get(abs_url, auth=(self.user, self.password))
         response.raise_for_status()
 
         return response


### PR DESCRIPTION
Closes #35. I missed the Basic Auth details and therefore requests to WP were failing. They now succeed which results in this workflow:

**[04/May/2021 15:03:11,634] Wcfmpp request. url=http://staging.lazona.coop/wp-json/wcfmmp/v1/settings/id/6**
[04/May/2021 15:03:12,951] Koiki request to https://rekistest.koiki.es/services/rekis/api/altaEnvios. body={'formatoEtiqueta': 'PDF', 'envios': [{'numPedido': 'wc_order_mtb7lqMmJRyfn', 'bultos': 1, 'kilos': 0.0, 'tipoServicio': '', 'reembolso': 0.0, 'observaciones': '', 'nombreDesti': 'Sergi', 'apellidoDesti': 'Alonso', 'direccionDesti': 'Travessera de Gràcia 264', 'direccionAdicionalDesti': '', 'numeroCalleDesti': '', 'codPostalDesti': '08025', 'poblacionDesti': 'Barcelona', 'provinciaDesti': 'B', 'paisDesti': 'ES', 'telefonoDesti': '653384286', 'emailDesti': 'sergi.alonso@coopdevs.org', **'nombreRemi': 'Quèviure', 'apellidoRemi': '', 'numeroCalleRemi': '', 'direccionRemi': '', 'codPostalRemi': '', 'poblacionRemi': '', 'provinciaRemi': '', 'paisRemi': 'ES', 'emailRemi': 'queviure@lazona.coop', 'telefonoRemi': ''**}], 'token': '4c615f32-8fc3-46a5-b41b-0acf5436aa3a'}
[04/May/2021 15:03:13,391] Koiki response. status=200, body={"respuesta":"102","mensaje":"ERROR IN THE RECEIVED DATA","envios":[{"numPedido":"wc_order_mtb7lqMmJRyfn","respuesta":"102","mensaje":"Error. No es posible recuperar la provincia del remitente","etiqueta":"","codBarras":""}]}
