### PR TITLE
Install Sentry's SDK

### DIFF
--- a/lazona_connector/settings.py
+++ b/lazona_connector/settings.py
@@ -13,6 +13,29 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 import os
 import dj_database_url
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+
+sentry_sdk.init(
+    dsn=os.getenv('SENTRY_DSN'),
+    integrations=[DjangoIntegration()],
+
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    # We recommend adjusting this value in production,
+    traces_sample_rate=1.0,
+
+    # If you wish to associate users to errors (assuming you are using
+    # django.contrib.auth) you may enable sending PII data.
+    send_default_pii=True,
+
+    # By default the SDK will try to use the SENTRY_RELEASE
+    # environment variable, or infer a git commit
+    # SHA as release, however you may want to set
+    # something more human-readable.
+    # release="myapp@1.0.0",
+)
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ pytz==2021.1
 redis==3.5.3
 requests==2.25.1
 responses==0.12.1
+sentry-sdk==1.1.0
 six==1.15.0
 sqlparse==0.4.1
 urllib3==1.26.4


### PR DESCRIPTION
Note this requires the ENV var `SENTRY_DSN` which is set up by Heroku when adding the Sentry's add-on from the UI.