### PR TITLE
Enable serving the app from N Heroku hosts

### DIFF
--- a/lazona_connector/settings.py
+++ b/lazona_connector/settings.py
@@ -49,7 +49,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get('DJANGO_DEBUG', '') != 'False'
 
-ALLOWED_HOSTS = ["lazona-connector-staging.herokuapp.com", "127.0.0.1", ".ngrok.io", "0.0.0.0"]
+ALLOWED_HOSTS = [".herokuapp.com", "127.0.0.1", ".ngrok.io", "0.0.0.0"]
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
This gives room for the production environment in Heroku as well as the existing staging.