### PR TITLE
Use signature auth only

### DIFF
--- a/api/authentication.py
+++ b/api/authentication.py
@@ -4,6 +4,7 @@ import hashlib
 import os
 
 from django.contrib.auth.models import User
+from django.conf import settings
 from rest_framework import authentication
 from rest_framework import exceptions
 
@@ -42,7 +43,7 @@ class SignatureValidation(authentication.BaseAuthentication):
         if signature != generated_signature:
             raise exceptions.AuthenticationFailed("Invalid payload checksum signature")
 
-        user = User.objects.filter(is_superuser=True).first()
+        user = User.objects.filter(username=settings.WC_WEBHOOK_USER).first()
         if not user:
             raise exceptions.AuthenticationFailed('No such user')
 

--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -16,3 +16,4 @@ koiki.logger = logging.getLogger('django.tests')
 koiki.auth_token = 'testing_auth_token'
 
 settings.CELERY_ALWAYS_EAGER = True
+settings.WC_WEBHOOK_USER = 'test_user'

--- a/api/tests/test_signature_validation.py
+++ b/api/tests/test_signature_validation.py
@@ -3,6 +3,7 @@ import os
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.contrib.auth.models import User
+from django.conf import settings
 
 from api.authentication import SignatureValidation
 import rest_framework
@@ -28,7 +29,7 @@ class SignatureValidationTests(TestCase):
         )
 
     def test_payload_signature_is_valid(self):
-        user = User(username="pau", is_superuser=True)
+        user = User(username=settings.WC_WEBHOOK_USER)
         user.save()
         # calculated via https://www.devglan.com/online-tools/hmac-sha256-online
 

--- a/api/tests/test_signature_validation.py
+++ b/api/tests/test_signature_validation.py
@@ -8,7 +8,7 @@ from api.authentication import SignatureValidation
 import rest_framework
 
 
-class PayloadSignatureTests(TestCase):
+class SignatureValidationTests(TestCase):
     def setUp(self):
         os.environ["WC_WEBHOOK_SECRET"] = "testcase"
         self.original_payload = '{"test": 1 }'

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -102,4 +102,4 @@ class DeliveryViewTests(TestCase):
 
         self.assertEqual(response.content,
                          b'{"detail":"Authentication credentials were not provided."}')
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/api/views.py
+++ b/api/views.py
@@ -1,16 +1,15 @@
-from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework import status
 
-from api.authentication import HostAuthentication, SignatureValidation
+from api.authentication import SignatureValidation
 from api.serializers import OrderSerializer
 from api.tasks import create_delivery
 
 
 class DeliveryList(APIView):
-    authentication_classes = [TokenAuthentication, HostAuthentication, SignatureValidation]
+    authentication_classes = [SignatureValidation]
     permission_classes = [IsAuthenticated]
 
     def post(self, request):

--- a/lazona_connector/settings.py
+++ b/lazona_connector/settings.py
@@ -176,3 +176,5 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
 #  STATIC_URL = '/static/'
+
+WC_WEBHOOK_USER = os.getenv('WC_WEBHOOK_USER')


### PR DESCRIPTION
There's no way we can configure Woocommerce (that I know of) to send a specific token provided by us as the HTTP Authorization header. As such, we can't rely on Django's REST Framework TokenAuthentication. Only on our SignatureValidation which implements Woocommerce's signature mechanism.

Also, given our custom authentication class needs to return a user record, it seemed best to return one that matches with these Woocommerce's webhooks when debugging things instead of forcing it to be super user. Pretty much like per-service users in Linux. This gives us room to change that user however we see fit in every environment.