### PR TITLE
Upgrade HTTPretty to 1.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ djangorestframework==3.12.2
 flake8==3.8.4
 flake8-django==1.1.1
 gunicorn==20.0.4
-httpretty==1.0.5
+httpretty==1.1.3
 idna==2.10
 kombu==5.0.2
 mccabe==0.6.1


### PR DESCRIPTION
I was expecting to see https://github.com/gabrielfalcao/HTTPretty/issues/388#issuecomment-840183825 but I'm afraid HTTPretty might be clashing with `responses` somehow and/or the duplicate initialization from api/tests/__init__.py and koiki/tests/__init__.py might be breaking things. Time to clean up.