### PR TITLE
Configure stricter security-related settings

### DIFF
--- a/lazona_connector/settings.py
+++ b/lazona_connector/settings.py
@@ -13,6 +13,8 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 import os
 import dj_database_url
 
+from django.conf import global_settings
+
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
@@ -172,6 +174,13 @@ USE_L10N = True
 
 USE_TZ = True
 
+
+# Security
+
+SECURE_SSL_REDIRECT = bool(os.getenv('SECURE_SSL_REDIRECT', global_settings.SECURE_SSL_REDIRECT))
+CSRF_COOKIE_SECURE = bool(os.getenv('CSRF_COOKIE_SECURE', global_settings.CSRF_COOKIE_SECURE))
+SESSION_COOKIE_SECURE = bool(os.getenv('SESSION_COOKIE_SECURE',
+                             global_settings.SESSION_COOKIE_SECURE))
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/


### PR DESCRIPTION
Closes #19 

I expected Django to read these from ENV itself but it seems it does not. For instance, while the ENV var is set settings.SECURE_SSL_REDIRECT` returns `False` from a shell.
    
I chose to only override the setting if the matching ENV var is set otherwise, we default to Django's default value.

I only left an issue that may need more in-depth investigation

```sh
❯ heroku run python manage.py check --deploy -a lazona-connector-production                <<<
Running python manage.py check --deploy on ⬢ lazona-connector-production... up, run.4811 (Hobby)
System check identified some issues:

WARNINGS:
?: (security.W004) You have not set a value for the SECURE_HSTS_SECONDS setting. If your entire site is served only over SSL, you may want to consider setting a value and enabling HTTP Strict Transport Security. Be sure to read the documentation first; enabling HSTS carelessly can cause serious, irreversible problems.
?: (security.W012) SESSION_COOKIE_SECURE is not set to True. Using a secure-only session cookie makes it more difficult for network traffic sniffers to hijack user sessions.

System check identified 2 issues (0 silenced).
```