### PR TITLE
Explicitly configure Celery's backend and broker

### DIFF
--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -1,5 +1,6 @@
 import httpretty
 import logging
+import os
 from django.conf import settings
 
 import koiki
@@ -17,3 +18,5 @@ koiki.auth_token = 'testing_auth_token'
 
 settings.CELERY_ALWAYS_EAGER = True
 settings.WC_WEBHOOK_USER = 'test_user'
+
+os.environ['REDIS_URL'] = 'rediss://test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db/postgres
       - DATABASE_DISABLE_SSL=true
-      - CELERY_BROKER_URL=redis://redis
+      - REDIS_URL=rediss://redis
     volumes:
       - .:/code
     ports:
@@ -38,7 +38,7 @@ services:
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db/postgres
       - DATABASE_DISABLE_SSL=true
-      - CELERY_BROKER_URL=redis://redis
+      - REDIS_URL=rediss://redis
     volumes:
       - .:/code
     depends_on:

--- a/koiki/tests/__init__.py
+++ b/koiki/tests/__init__.py
@@ -1,5 +1,6 @@
 import httpretty
 import logging
+import os
 from django.conf import settings
 
 import koiki
@@ -16,3 +17,5 @@ koiki.logger = logging.getLogger('django.tests')
 koiki.auth_token = 'testing_auth_token'
 
 settings.CELERY_ALWAYS_EAGER = True
+
+os.environ['REDIS_URL'] = 'rediss://test'

--- a/lazona_connector/celery.py
+++ b/lazona_connector/celery.py
@@ -5,7 +5,11 @@ import os
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'lazona_connector.settings')
 
-app = Celery('lazona_connector')
+app = Celery(
+    'lazona_connector',
+    broker=os.environ['REDIS_URL'],
+    backend=f'{os.environ["REDIS_URL"]}?ssl_cert_reqs=none'
+)
 app.config_from_object(settings)
 app.autodiscover_tasks()
 


### PR DESCRIPTION
Configuring Celery's results backend is becoming a bit tricky. Apparently, as I've seen in https://blog.heroku.com/securing-celery,
Redis doesn't support SSL so we need to purposefully disable SSL while using Redi's secure protocol (rediss://).

That's why I decided to make Celery's configuration a bit more explicit and greppeable moving it from ENV vars only to code. Without `ssl_cert_reqs` things won't work on Heroku so better to have a bit more obvious.