### PR TITLE
Avoids raising E_REDIS_SSL_PARAMS_AND_SCHEME_MISMATCH

### DIFF
--- a/lazona_connector/celery.py
+++ b/lazona_connector/celery.py
@@ -5,10 +5,16 @@ import os
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'lazona_connector.settings')
 
+redis_url = os.environ['REDIS_URL']
+if redis_url.lower().startswith('rediss://'):
+    backend_url = f'{redis_url}?ssl_cert_reqs=none'
+else:
+    backend_url = redis_url
+
 app = Celery(
     'lazona_connector',
-    broker=os.environ['REDIS_URL'],
-    backend=f'{os.environ["REDIS_URL"]}?ssl_cert_reqs=none'
+    broker=redis_url,
+    backend=backend_url
 )
 app.config_from_object(settings)
 app.autodiscover_tasks()


### PR DESCRIPTION
This avoids E_REDIS_SSL_PARAMS_AND_SCHEME_MISMATCH exception due to adding the "ssl_cert_reqs" parameter when having a redis:// deployment.