### PR TITLE
Fix/use vendor mail from wp user

### DIFF
--- a/api/tasks.py
+++ b/api/tasks.py
@@ -29,6 +29,6 @@ def _check_customer_is_partner(email):
 
 @app.task
 def update_user_as_partner(email):
-    wp_user = WPUser().fetch(email)
+    wp_user = WPUser().fetch_by_email(email)
     if wp_user.roles and "customer" in wp_user.roles:
         wp_user.update(roles=wordpress.wp_partner_role)

--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -4,6 +4,7 @@ import os
 from django.conf import settings
 
 import koiki
+import wordpress
 
 httpretty.enable(allow_net_connect=False)
 
@@ -15,6 +16,10 @@ koiki.wcfmmp_password = 'test_wcfmmp_password'
 
 koiki.logger = logging.getLogger('django.tests')
 koiki.auth_token = 'testing_auth_token'
+
+wordpress.wp_host = 'https://wp_testing_host'
+wordpress.wp_user = 'test_wp_user'
+wordpress.wp_password = 'test_wp_password'
 
 settings.CELERY_ALWAYS_EAGER = True
 settings.WC_WEBHOOK_USER = 'test_user'

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -47,7 +47,6 @@ class DeliveryViewTests(TestCase):
             }]
         }
         self.api_url = 'https://testing_host/rekis/api/altaEnvios'
-
         self.user = User.objects.create_superuser('admin', 'admin@example.com', 'pass')
 
         self.client = APIClient()
@@ -60,7 +59,6 @@ class DeliveryViewTests(TestCase):
                 status=200,
                 content_type='application/json',
                 body=json.dumps({
-                    "store_email": "queviure@lazona.coop",
                     "phone": "",
                     "address": {
                         "street_1": "",
@@ -70,6 +68,18 @@ class DeliveryViewTests(TestCase):
                         "country": "ES",
                         "state": ""
                     }
+                })
+        )
+        httpretty.register_uri(
+                httpretty.GET,
+                'https://wp_testing_host/wp-json/wp/v2/users/6?context=edit',
+                status=200,
+                content_type='application/json',
+                body=json.dumps({
+                    "id": 6,
+                    "username": "Queviure",
+                    "email": "queviure@lazona.coop",
+                    "roles": ["testrole"],
                 })
         )
         httpretty.register_uri(

--- a/koiki/tests/test_client.py
+++ b/koiki/tests/test_client.py
@@ -60,7 +60,6 @@ class KoikiTest(TestCase):
         responses.add(responses.GET, f'{koiki.wcfmmp_host}/wp-json/wcfmmp/v1/settings/id/6',
                       status=200,
                       json={
-                        "store_email": "queviure@lazona.coop",
                         "phone": "",
                         "address": {
                             "street_1": "",
@@ -71,6 +70,19 @@ class KoikiTest(TestCase):
                             "state": ""
                         }
                       })
+
+        responses.add(
+                responses.GET,
+                'https://wp_testing_host/wp-json/wp/v2/users/6?context=edit',
+                status=200,
+                content_type='application/json',
+                json={
+                    "id": 6,
+                    "username": "Queviure",
+                    "email": "queviure@lazona.coop",
+                    "roles": ["testrole"],
+                }
+        )
 
     @responses.activate
     @patch('koiki.logger', autospec=True)

--- a/koiki/tests/test_create_delivery.py
+++ b/koiki/tests/test_create_delivery.py
@@ -78,7 +78,6 @@ class CreateDeliveryTest(TestCase):
         responses.add(responses.GET, f'{koiki.wcfmmp_host}/wp-json/wcfmmp/v1/settings/id/5',
                       status=200,
                       json={
-                          "store_email": "detergents@agranel.coop",
                           "phone": "93333333",
                           "address": {
                               "street_1": "Sant Antoni Maria Claret, 175",
@@ -93,7 +92,6 @@ class CreateDeliveryTest(TestCase):
         responses.add(responses.GET, f'{koiki.wcfmmp_host}/wp-json/wcfmmp/v1/settings/id/6',
                       status=200,
                       json={
-                        "store_email": "queviure@lazona.coop",
                         "phone": "",
                         "address": {
                             "street_1": "",
@@ -104,6 +102,31 @@ class CreateDeliveryTest(TestCase):
                             "state": ""
                         }
                       })
+
+        responses.add(
+                responses.GET,
+                'https://wp_testing_host/wp-json/wp/v2/users/5?context=edit',
+                status=200,
+                content_type='application/json',
+                json={
+                    "id": 5,
+                    "username": "A Granel",
+                    "email": "detergents@agranel.coop",
+                    "roles": ["testrole"],
+                }
+        )
+        responses.add(
+                responses.GET,
+                'https://wp_testing_host/wp-json/wp/v2/users/6?context=edit',
+                status=200,
+                content_type='application/json',
+                json={
+                    "id": 6,
+                    "username": "Queviure",
+                    "email": "queviure@lazona.coop",
+                    "roles": ["testrole"],
+                }
+        )
 
         body = CreateDelivery(self.order).body()
         deliveries = body['envios']

--- a/koiki/tests/test_woocommerce_models.py
+++ b/koiki/tests/test_woocommerce_models.py
@@ -56,7 +56,6 @@ class WooocommerceModelsTest(TestCase):
             status=200,
             content_type='application/json',
             body=json.dumps({
-                "store_email": "store@example.com",
                 "phone": "+34666554433",
                 "address": {
                     "street_1": "Passeig de Gràcia 1",
@@ -67,6 +66,18 @@ class WooocommerceModelsTest(TestCase):
                     "state": "Barcelona"
                 }
             })
+        )
+        httpretty.register_uri(
+                httpretty.GET,
+                'https://wp_testing_host/wp-json/wp/v2/users/1?context=edit',
+                status=200,
+                content_type='application/json',
+                body=json.dumps({
+                    "id": 1,
+                    "username": "Store",
+                    "email": "store@example.com",
+                    "roles": ["testrole"],
+                })
         )
 
         vendor = Vendor(id=1, name='name')

--- a/koiki/woocommerce/models.py
+++ b/koiki/woocommerce/models.py
@@ -32,11 +32,11 @@ class Vendor():
     def fetch(self):
         response = self.client.request(f"settings/id/{self.id}")
         self._convert_to_resource(response)
-        self.fetch_email()
+        self._fetch_email()
         return self
 
-    def fetch_email(self):
-        wp_user = WPUser().get(self.id)
+    def _fetch_email(self):
+        wp_user = WPUser().fetch_by_email(self.id)
         self.email = wp_user.email
 
     def _convert_to_resource(self, response):

--- a/koiki/woocommerce/models.py
+++ b/koiki/woocommerce/models.py
@@ -1,6 +1,6 @@
 from koiki.woocommerce.wcfmmp import APIClient
 from koiki.woocommerce.state import State
-
+from wordpress.user import WPUser
 import re
 
 
@@ -32,7 +32,12 @@ class Vendor():
     def fetch(self):
         response = self.client.request(f"settings/id/{self.id}")
         self._convert_to_resource(response)
+        self.fetch_email()
         return self
+
+    def fetch_email(self):
+        wp_user = WPUser().get(self.id)
+        self.email = wp_user.email
 
     def _convert_to_resource(self, response):
         body = response.json()
@@ -42,7 +47,6 @@ class Vendor():
         self.city = body['address']['city']
         self.state = self._build_state(body['address']['state'])
         self.country = self._build_country(body['address']['country'])
-        self.email = body['store_email']
         self.phone = body['phone']
 
     def __eq__(self, other):

--- a/koiki/woocommerce/models.py
+++ b/koiki/woocommerce/models.py
@@ -36,7 +36,7 @@ class Vendor():
         return self
 
     def _fetch_email(self):
-        wp_user = WPUser().fetch_by_email(self.id)
+        wp_user = WPUser().fetch_by_id(self.id)
         self.email = wp_user.email
 
     def _convert_to_resource(self, response):

--- a/wordpress/tests/test_wpuser.py
+++ b/wordpress/tests/test_wpuser.py
@@ -37,7 +37,7 @@ class WPUserTest(TestCase):
             },
         )
 
-        wp_user.fetch(self.email)
+        wp_user.fetch_by_email(self.email)
 
         self.assertEqual(wp_user.roles, ["testrole"])
         self.assertEqual(wp_user.email, self.email)
@@ -71,9 +71,9 @@ class WPUserTest(TestCase):
     @patch("api.tasks.WPUser", autospec=True)
     def test_tasks_check_customer_is_not_partner(self, mock_wp_user):
         mock_wp_user.return_value = self.mock_client
-        self.mock_client.fetch.return_value = self.mock_client
+        self.mock_client.fetch_by_email.return_value = self.mock_client
         self.mock_client.roles = ["customer"]
 
         update_user_as_partner(self.email)
-        self.mock_client.fetch.assert_called_once_with(self.email)
+        self.mock_client.fetch_by_email.assert_called_once_with(self.email)
         self.mock_client.update.assert_called_once_with(roles="test_partner_role")

--- a/wordpress/user.py
+++ b/wordpress/user.py
@@ -17,10 +17,10 @@ class WPUser:
         body = self.client.get_request(f'users/?search={email}')
         if len(body):
             user_id = body[0]['id']
-            self.get(user_id)
+            self.fetch_by_email(user_id)
         return self
 
-    def get(self, user_id):
+    def fetch_by_email(self, user_id):
         body = self.client.get_request(f'users/{user_id}?context=edit')
         self._convert_to_resource(body)
         return self

--- a/wordpress/user.py
+++ b/wordpress/user.py
@@ -13,14 +13,14 @@ class WPUser:
         self.roles = None
         self.username = None
 
-    def fetch(self, email):
+    def fetch_by_email(self, email):
         body = self.client.get_request(f'users/?search={email}')
         if len(body):
             user_id = body[0]['id']
-            self.fetch_by_email(user_id)
+            self.fetch_by_id(user_id)
         return self
 
-    def fetch_by_email(self, user_id):
+    def fetch_by_id(self, user_id):
         body = self.client.get_request(f'users/{user_id}?context=edit')
         self._convert_to_resource(body)
         return self

--- a/wordpress/user.py
+++ b/wordpress/user.py
@@ -17,9 +17,12 @@ class WPUser:
         body = self.client.get_request(f'users/?search={email}')
         if len(body):
             user_id = body[0]['id']
-            body = self.client.get_request(f'users/{user_id}', "context=edit")
-            self._convert_to_resource(body)
+            self.get(user_id)
+        return self
 
+    def get(self, user_id):
+        body = self.client.get_request(f'users/{user_id}?context=edit')
+        self._convert_to_resource(body)
         return self
 
     def _convert_to_resource(self, body):


### PR DESCRIPTION
Fetches the vendor mail from the WP user's settings and not the vendor's profile.

closes #66 