### PR TITLE
feature/send-koiki-error-mail

### DIFF
--- a/api/tasks.py
+++ b/api/tasks.py
@@ -1,4 +1,5 @@
 from koiki.client import Client
+from koiki.email import FailedDeliveryMail, SuccessDeliveryMail
 from sugarcrm.customer import Customer
 import wordpress
 from wordpress.user import WPUser
@@ -10,9 +11,11 @@ def create_delivery(order):
     deliveries_by_vendor = Client(order).create_delivery()
     for delivery in deliveries_by_vendor:
         if not delivery._is_errored():
-            delivery.send_mail_to_vendor()
+            email = SuccessDeliveryMail(delivery)
+            email.send()
         else:
-            delivery.send_error_mail_to_admin()
+            email = FailedDeliveryMail(delivery)
+            email.send()
 
 
 @app.task

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -11,11 +11,17 @@ def create_delivery(order):
     deliveries_by_vendor = Client(order).create_delivery()
     for delivery in deliveries_by_vendor:
         if not delivery._is_errored():
-            email = SuccessDeliveryMail(delivery)
-            email.send()
+            SuccessDeliveryMail(
+                pdf_path=delivery.print_pdf(),
+                recipient=delivery.vendor.email,
+                order_id=delivery.order_id
+            ).send()
         else:
-            email = FailedDeliveryMail(delivery)
-            email.send()
+            FailedDeliveryMail(
+                order_id=delivery.order_id,
+                error_returned=delivery.data.get("mensaje"),
+                req_body=delivery.req_body
+            ).send()
 
 
 @app.task

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -11,6 +11,8 @@ def create_delivery(order):
     for delivery in deliveries_by_vendor:
         if not delivery._is_errored():
             delivery.send_mail_to_vendor()
+        else:
+            delivery.send_error_mail_to_admin()
 
 
 @app.task

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -10,17 +10,17 @@ from lazona_connector.celery import app
 def create_delivery(order):
     deliveries_by_vendor = Client(order).create_delivery()
     for delivery in deliveries_by_vendor:
-        if not delivery._is_errored():
-            SuccessDeliveryMail(
-                pdf_path=delivery.print_pdf(),
-                recipient=delivery.vendor.email,
-                order_id=delivery.order_id
-            ).send()
-        else:
+        if delivery._is_errored():
             FailedDeliveryMail(
                 order_id=delivery.order_id,
                 error_returned=delivery.data.get("mensaje"),
                 req_body=delivery.req_body
+            ).send()
+        else:
+            SuccessDeliveryMail(
+                pdf_path=delivery.print_pdf(),
+                recipient=delivery.vendor.email,
+                order_id=delivery.order_id
             ).send()
 
 

--- a/api/templates/contact_template.txt
+++ b/api/templates/contact_template.txt
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% blocktranslate %}Hola, la teva tenda ha rebut la comanda: {{url_comanda}}
+{% blocktranslate %}Hola, la teva tenda ha rebut la comanda: {{url_wc_order}}
 
 Adjuntem el PDF per a imprimir i pegar al paquet a enviar.
 {% endblocktranslate %}

--- a/api/templates/error_template.txt
+++ b/api/templates/error_template.txt
@@ -3,7 +3,7 @@ La notificació a l'empresa d'enviament (Koiki) de la comanda {{url_wc_order}} h
 {{error_returned}}
 
 
-La comanda romandrà en estat "S'està processant" i no serà enviada al client fins que no s'actualitzen els detalls de la comanda que provoquen l'error en Koiki.
+La comanda romandrà en estat "S'està processant" i no serà enviada al client fins que no s'actualitzen els detalls de la comanda que provoquen l'error a Koiki.
 
 Detalls de l'enviament a Koiki:
 

--- a/api/templates/error_template.txt
+++ b/api/templates/error_template.txt
@@ -1,0 +1,9 @@
+S'ha rebut un error de KOIKI per a la comanda: {{url_wc_order}}
+
+{% autoescape off %}
+Data enviada:
+{{req_body}}
+
+Error rebut:
+{{error_returned}}
+{% endautoescape %}

--- a/api/templates/error_template.txt
+++ b/api/templates/error_template.txt
@@ -1,9 +1,11 @@
-S'ha rebut un error de KOIKI per a la comanda: {{url_wc_order}}
-
+La notificació a l'empresa d'enviament (Koiki) de la comanda {{url_wc_order}} ha fallat amb el següent error:
 {% autoescape off %}
-Data enviada:
-{{req_body}}
-
-Error rebut:
 {{error_returned}}
+
+
+La comanda romandrà en estat "S'està processant" i no serà enviada al client fins que no s'actualitzen els detalls de la comanda que provoquen l'error en Koiki.
+
+Detalls de l'enviament a Koiki:
+
+{{req_body| pprint}}
 {% endautoescape %}

--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -13,7 +13,7 @@ koiki.host = 'https://testing_host'
 koiki.wcfmmp_host = 'https://wcfmmp_testing_host'
 koiki.wcfmmp_user = 'test_wcfmmp_user'
 koiki.wcfmmp_password = 'test_wcfmmp_password'
-
+koiki.error_mail_recipients = ['admin@email.com']
 koiki.logger = logging.getLogger('django.tests')
 koiki.auth_token = 'testing_auth_token'
 

--- a/api/tests/test_tasks.py
+++ b/api/tests/test_tasks.py
@@ -123,8 +123,53 @@ class TasksTests(TestCase):
         mock_email.send.return_value = True
 
         create_delivery(order)
-        mock_logger.info.assert_called_once_with(
-            "Sending Koiki pdf to email test@test.es")
+        mock_logger.info.assert_called_once_with("Sending Koiki pdf to email test@test.es")
         self.assertIn({'to': ['test@test.es']}, mock_email.call_args)
         message = mock_email.call_args[0][1]
         self.assertIn(f"{koiki.wcfmmp_host}area-privada/orders-details/33", message)
+
+    @responses.activate
+    @patch('koiki.delivery.EmailMessage', autospec=True)
+    @patch('koiki.delivery.logger', autospec=True)
+    def test_create_delivery_sends_error_email(self, mock_logger, mock_email):
+        responses.add(responses.POST, 'https://testing_host/rekis/api/altaEnvios', status=200,
+                      json={
+                        'respuesta': '102',
+                        'mensaje': 'ERROR',
+                        'envios': [{'numPedido': '124', 'respuesta': '102',
+                                    'mensaje': 'Missing field X'}]
+                      })
+
+        serializer = OrderSerializer(data=self.data)
+        self.assertTrue(serializer.is_valid())
+        order = serializer.validated_data
+
+        mock_email.send.return_value = True
+
+        create_delivery(order)
+        mock_logger.info.assert_called_once_with("Sending Koiki error to admins for order 33")
+        self.assertIn({'to': ['admin@email.com']}, mock_email.call_args)
+        message = mock_email.call_args[0][1]
+        self.assertIn(f"{koiki.wcfmmp_host}area-privada/orders-details/33", message)
+        self.assertIn("Missing field X", message)
+
+    @responses.activate
+    @patch('koiki.delivery.EmailMessage', autospec=True)
+    @patch('koiki.delivery.logger', autospec=True)
+    def test_create_delivery_sends_error_email_default_error(self, mock_logger, mock_email):
+        responses.add(responses.POST, 'https://testing_host/rekis/api/altaEnvios', status=200,
+                      json={
+                        'respuesta': '102',
+                        'mensaje': 'ERROR',
+                        'envios': [{'numPedido': '124', 'respuesta': '102',
+                                    'mensaje': ''}]
+                      })
+
+        serializer = OrderSerializer(data=self.data)
+        self.assertTrue(serializer.is_valid())
+        order = serializer.validated_data
+        mock_email.send.return_value = True
+
+        create_delivery(order)
+        message = mock_email.call_args[0][1]
+        self.assertIn("Missatge d'error no proporcionat", message)

--- a/koiki/__init__.py
+++ b/koiki/__init__.py
@@ -9,3 +9,4 @@ wcfmmp_password = os.getenv('WCFMMP_PASSWORD')
 
 logger = logging.getLogger('django.server')
 auth_token = os.getenv('KOIKI_AUTH_TOKEN')
+error_mail_recipients = os.getenv("KOIKI_ERROR_MAIL_RECIPIENTS").split(",")

--- a/koiki/__init__.py
+++ b/koiki/__init__.py
@@ -9,4 +9,4 @@ wcfmmp_password = os.getenv('WCFMMP_PASSWORD')
 
 logger = logging.getLogger('django.server')
 auth_token = os.getenv('KOIKI_AUTH_TOKEN')
-error_mail_recipients = os.getenv("KOIKI_ERROR_MAIL_RECIPIENTS","").split(",")
+error_mail_recipients = os.getenv("KOIKI_ERROR_MAIL_RECIPIENTS", "").split(",")

--- a/koiki/__init__.py
+++ b/koiki/__init__.py
@@ -9,4 +9,4 @@ wcfmmp_password = os.getenv('WCFMMP_PASSWORD')
 
 logger = logging.getLogger('django.server')
 auth_token = os.getenv('KOIKI_AUTH_TOKEN')
-error_mail_recipients = os.getenv("KOIKI_ERROR_MAIL_RECIPIENTS").split(",")
+error_mail_recipients = os.getenv("KOIKI_ERROR_MAIL_RECIPIENTS","").split(",")

--- a/koiki/client.py
+++ b/koiki/client.py
@@ -33,8 +33,9 @@ class Client():
         if response.status_code == status.HTTP_200_OK:
             for num, delivery_data in enumerate(response_body['envios']):
                 vendor = self.order.vendors[num]
+                req_body_shipping = req_body['envios'][num]
                 delivery_data['order_id'] = self.order.order_id
-                delivery = Delivery(delivery_data, vendor)
+                delivery = Delivery(delivery_data, vendor, req_body_shipping)
                 if delivery._is_errored():
                     self._log(delivery.data.get('respuesta'), delivery.data, level='error')
                 else:

--- a/koiki/delivery.py
+++ b/koiki/delivery.py
@@ -57,11 +57,13 @@ class Delivery:
         send_mail.send(fail_silently=False)
 
     def send_error_mail_to_admin(self):
-
+        error_returned = self.data.get("mensaje")
+        if not error_returned:
+            error_returned = "Missatge d'error no proporcionat"
         context = {
             'url_wc_order': f'{wcfmmp_host}area-privada/orders-details/{self.order_id}',
             'req_body': self.req_body,
-            'error_returned': self.data.get("mensaje", "missatge d'error no proporcionat"),
+            'error_returned': error_returned,
         }
         logger.info('Sending Koiki error to admins for order {}'.format(self.order_id))
         message = render_to_string('error_template.txt', context)

--- a/koiki/delivery.py
+++ b/koiki/delivery.py
@@ -12,7 +12,7 @@ from koiki import wcfmmp_host, logger, error_mail_recipients
 class Delivery:
     pdf_folder = "pdf_barcodes"
 
-    def __init__(self, data, vendor, req_body):
+    def __init__(self, data, vendor, req_body={}):
         self.data = data
         self.vendor = vendor
         self.req_body = req_body
@@ -42,7 +42,7 @@ class Delivery:
     def send_mail_to_vendor(self):
         self.print_pdf()
         context = {
-            'url_comanda': f'{wcfmmp_host}area-privada/orders-details/{self.order_id}'
+            'url_wc_order': f'{wcfmmp_host}area-privada/orders-details/{self.order_id}'
         }
         logger.info('Sending Koiki pdf to email {}'.format(self.vendor.email))
         message = render_to_string('contact_template.txt', context)
@@ -61,7 +61,7 @@ class Delivery:
         context = {
             'url_wc_order': f'{wcfmmp_host}area-privada/orders-details/{self.order_id}',
             'req_body': self.req_body,
-            'error_returned': self.data.get("mensaje", ""),
+            'error_returned': self.data.get("mensaje", "missatge d'error no proporcionat"),
         }
         logger.info('Sending Koiki error to admins for order {}'.format(self.order_id))
         message = render_to_string('error_template.txt', context)

--- a/koiki/delivery.py
+++ b/koiki/delivery.py
@@ -3,10 +3,6 @@ import os
 
 # TODO: convert this class into Django Model in order to link Koiki's shipping,
 # with WC purchase and PDF
-from django.core.mail import EmailMessage
-from django.template.loader import render_to_string
-from django.utils.translation import gettext as _
-from koiki import wcfmmp_host, logger, error_mail_recipients
 
 
 class Delivery:
@@ -32,45 +28,10 @@ class Delivery:
 
     def print_pdf(self):
         content = base64.b64decode(self.data["etiqueta"])
+        pdf_path = os.path.join(self.pdf_folder, f"{self.shipment_id}.pdf")
+        if not os.path.exists(pdf_path):
+            pdf = open(pdf_path, "wb")
+            pdf.write(content)
+            pdf.close()
 
-        pdf = open(os.path.join(self.pdf_folder, f"{self.shipment_id}.pdf"), "wb")
-        pdf.write(content)
-        pdf.close()
-
-        return pdf
-
-    def send_mail_to_vendor(self):
-        self.print_pdf()
-        context = {
-            'url_wc_order': f'{wcfmmp_host}area-privada/orders-details/{self.order_id}'
-        }
-        logger.info('Sending Koiki pdf to email {}'.format(self.vendor.email))
-        message = render_to_string('contact_template.txt', context)
-        send_mail = EmailMessage(
-            _("Enviament Koiki per a la comanda: {}").format(self.order_id),
-            message,
-            to=[self.vendor.email]
-        )
-        pdf = open(os.path.join(self.pdf_folder, f"{self.shipment_id}.pdf"), "rb")
-        send_mail.attach(f"{self.shipment_id}.pdf", pdf.read(), "application/pdf")
-
-        send_mail.send(fail_silently=False)
-
-    def send_error_mail_to_admin(self):
-        error_returned = self.data.get("mensaje")
-        if not error_returned:
-            error_returned = "Missatge d'error no proporcionat"
-        context = {
-            'url_wc_order': f'{wcfmmp_host}area-privada/orders-details/{self.order_id}',
-            'req_body': self.req_body,
-            'error_returned': error_returned,
-        }
-        logger.info('Sending Koiki error to admins for order {}'.format(self.order_id))
-        message = render_to_string('error_template.txt', context)
-        send_mail = EmailMessage(
-            _("Error enviament Koiki per a la comanda: {}").format(self.order_id),
-            message,
-            to=error_mail_recipients
-        )
-
-        send_mail.send(fail_silently=False)
+        return pdf_path

--- a/koiki/email.py
+++ b/koiki/email.py
@@ -7,13 +7,12 @@ from koiki import wcfmmp_host, logger, error_mail_recipients
 
 
 class SuccessDeliveryMail:
-    def __init__(self, delivery):
-        self.pdf_path = delivery.print_pdf()
-        self.recipient = delivery.vendor.email
-        self.order_id = delivery.order_id
+    def __init__(self, pdf_path, recipient, order_id):
+        self.pdf_path = pdf_path
+        self.recipient = recipient
+        self.order_id = order_id
 
-        context = {"url_wc_order": f"{wcfmmp_host}area-privada/orders-details/{self.order_id}"}
-
+        context = {"url_wc_order": f"{wcfmmp_host}area-privada/orders-details/{order_id}"}
         self.message = render_to_string("contact_template.txt", context)
 
     def send(self):
@@ -25,21 +24,19 @@ class SuccessDeliveryMail:
         )
 
         pdf_filename = os.path.basename(self.pdf_path)
-        print('self.pdf_path', self.pdf_path)
         send_mail.attach(pdf_filename, open(self.pdf_path, "rb").read(), "application/pdf")
 
         return send_mail.send(fail_silently=False)
 
 
 class FailedDeliveryMail:
-    def __init__(self, delivery):
-        self.order_id = delivery.order_id
-        error_returned = delivery.data.get("mensaje")
+    def __init__(self, order_id, error_returned, req_body={}):
+        self.order_id = order_id
         if not error_returned:
             error_returned = "Missatge d'error no proporcionat"
         context = {
-            "url_wc_order": f"{wcfmmp_host}area-privada/orders-details/{self.order_id}",
-            "req_body": delivery.req_body,
+            "url_wc_order": f"{wcfmmp_host}area-privada/orders-details/{order_id}",
+            "req_body": req_body,
             "error_returned": error_returned,
         }
         self.message = render_to_string("error_template.txt", context)

--- a/koiki/email.py
+++ b/koiki/email.py
@@ -1,0 +1,56 @@
+import os.path
+from django.core.mail import EmailMessage
+from django.template.loader import render_to_string
+from django.utils.translation import gettext as _
+
+from koiki import wcfmmp_host, logger, error_mail_recipients
+
+
+class SuccessDeliveryMail:
+    def __init__(self, delivery):
+        self.pdf_path = delivery.print_pdf()
+        self.recipient = delivery.vendor.email
+        self.order_id = delivery.order_id
+
+        context = {"url_wc_order": f"{wcfmmp_host}area-privada/orders-details/{self.order_id}"}
+
+        self.message = render_to_string("contact_template.txt", context)
+
+    def send(self):
+        logger.info("Sending Koiki pdf to email {}".format(self.recipient))
+        send_mail = EmailMessage(
+            _("Enviament Koiki per a la comanda: {}").format(self.order_id),
+            self.message,
+            to=[self.recipient],
+        )
+
+        pdf_filename = os.path.basename(self.pdf_path)
+        print('self.pdf_path', self.pdf_path)
+        send_mail.attach(pdf_filename, open(self.pdf_path, "rb").read(), "application/pdf")
+
+        return send_mail.send(fail_silently=False)
+
+
+class FailedDeliveryMail:
+    def __init__(self, delivery):
+        self.order_id = delivery.order_id
+        error_returned = delivery.data.get("mensaje")
+        if not error_returned:
+            error_returned = "Missatge d'error no proporcionat"
+        context = {
+            "url_wc_order": f"{wcfmmp_host}area-privada/orders-details/{self.order_id}",
+            "req_body": delivery.req_body,
+            "error_returned": error_returned,
+        }
+        self.message = render_to_string("error_template.txt", context)
+
+    def send(self):
+        logger.info("Sending Koiki error to admins for order {}".format(self.order_id))
+
+        send_mail = EmailMessage(
+            _("Error enviament Koiki per a la comanda: {}").format(self.order_id),
+            self.message,
+            to=error_mail_recipients,
+        )
+
+        return send_mail.send(fail_silently=False)


### PR DESCRIPTION
Closes #82 
Send email per Koiki's deliveries error to the the separated comma list added into a env var KOIKI_ERROR_MAIL_RECIPIENTS.
