### PR TITLE
make client simpler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ SECRET_KEY="your_secret_here"
 KOIKI_HOST="https://rekistest.koiki.es/services"
 KOIKI_AUTH_TOKEN="your_auth_token here"
 
+# Authentication for koiki tracking API.
+KOIKI_TRACKING_HOST="your_tracking_url"
+KOIKI_TRACKING_AUTH_TOKEN="your_auth_token here"
+
 # Details to connect to WCFM, the Marketplace plugin's API on Woocommerce.
 WCFMMP_HOST="your_wp_woocomerce_url"
 WCFMMP_USER="your_wp_woocomerce_user"

--- a/.envrc.example
+++ b/.envrc.example
@@ -5,6 +5,10 @@ export SECRET_KEY="your_secret_here"
 export KOIKI_HOST="https://rekistest.koiki.es/services"
 export KOIKI_AUTH_TOKEN="your_auth_token here"
 
+# Authentication for koiki tracking API.
+export KOIKI_TRACKING_HOST="your_tracking_url"
+export KOIKI_TRACKING_AUTH_TOKEN="your_auth_token here"
+
 # Details to connect to WCFM, the Marketplace plugin's API on Woocommerce.
 export WCFMMP_HOST="your_wp_woocomerce_url"
 export WCFMMP_USER="your_wp_woocomerce_user"

--- a/api/admin.py
+++ b/api/admin.py
@@ -8,8 +8,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from .models import Shipment
 from koiki.woocommerce.woocommerce import APIClient
 from api.serializers import OrderSerializer
-from api.tasks import create_or_update_delivery
-from koiki.client import Client
+from api.tasks import create_or_update_delivery, update_delivery_status
 
 
 @admin.register(Shipment)
@@ -53,8 +52,11 @@ class ShipmentAdmin(admin.ModelAdmin):
 
     def update_delivery_status(self, request, shipment_id):
         shipment_model = Shipment.objects.get(pk=shipment_id)
-        _ = Client().update_delivery_status(shipment_model.delivery_id)
-        return HttpResponse(f"updating delivery status of {shipment_id}")
+        update_delivery_status(shipment_model.delivery_id)
+        return HttpResponse(
+            f"updating delivery status of {shipment_id}",
+            status=status.HTTP_200_OK
+        )
 
     def shipment_actions(self, obj):
         if obj.pk:

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -43,6 +43,12 @@ def create_or_update_delivery(order_data, vendor_id=None):
 
 
 @app.task
+def update_delivery_status(delivery_id):
+    shipment_status = Client().update_delivery_status(delivery_id)
+    return shipment_status.get_data_val('status_code')
+
+
+@app.task
 def update_customer_if_is_partner(email):
     if _check_customer_is_partner(email):
         update_user_as_partner.delay(email)

--- a/koiki/delivery_create.py
+++ b/koiki/delivery_create.py
@@ -1,15 +1,18 @@
 from koiki.resources import Sender, Recipient, Shipment
 from koiki.woocommerce.resources import Shipping, Billing
+from lazona_connector.vars import koiki_host, koiki_auth_token
 
 
 class CreateDelivery():
     LABEL_FORMAT = 'PDF'
-    RESOURCE_PATH = '/rekis/api/altaEnvios'
 
     def __init__(self, order):
         self.order = order
         self.shipping = Shipping(order.data['shipping'])
         self.billing = Billing(order.data['billing'])
+
+    def url(self):
+        return f'{koiki_host}/rekis/api/altaEnvios'
 
     def body(self):
         return {
@@ -17,8 +20,8 @@ class CreateDelivery():
             'envios': self._deliveries()
         }
 
-    def url(self):
-        return self.RESOURCE_PATH
+    def auth_body(self):
+        return {**self.body(), **{"token": koiki_auth_token}}
 
     # Builds a single delivery for each vendor, aggregating the line items that vendor sold
     def _deliveries(self):

--- a/koiki/delivery_status.py
+++ b/koiki/delivery_status.py
@@ -1,0 +1,17 @@
+class DeliveryStatus():
+
+    def __init__(self, response_body={}):
+        self.response_body = response_body
+
+    def to_dict(self):
+        return {
+            "status_txt": self._get_current_val('codEstado'),
+            "status_code": self._get_current_val('codEstado'),
+            "status_date": self._get_current_val('codEstado'),
+        }
+
+    def _get_current_val(self, key):
+        return "test"
+
+    def get_data_val(self, key):
+        return self.to_dict()[key]

--- a/koiki/delivery_update.py
+++ b/koiki/delivery_update.py
@@ -1,9 +1,7 @@
-# from koiki.resources import Sender, Recipient, Shipment
-# from koiki.woocommerce.resources import Shipping, Billing
+from lazona_connector.vars import koiki_tracking_host, koiki_tracking_auth_token
 
 
 class UpdateDelivery():
-    RESOURCE_PATH = '/kis/api/v1/service/track/see'
 
     def __init__(self, delivery_id):
         self.delivery_id = delivery_id
@@ -13,5 +11,8 @@ class UpdateDelivery():
             'code': self.delivery_id
         }
 
+    def auth_body(self):
+        return {**self.body(), **{"token": koiki_tracking_auth_token}}
+
     def url(self):
-        return self.RESOURCE_PATH
+        return f'{koiki_tracking_host}/kis/api/v1/service/track/see'

--- a/koiki/tests/test_client.py
+++ b/koiki/tests/test_client.py
@@ -161,6 +161,6 @@ class KoikiTest(TestCase):
         response.status_code = 200
         post_mock.return_value = response
 
-        Client(auth_token='xxx').create_delivery(self.order)
+        Client().create_delivery(self.order)
 
         post_mock.assert_called()

--- a/koiki/tests/test_create_delivery.py
+++ b/koiki/tests/test_create_delivery.py
@@ -180,4 +180,7 @@ class CreateDeliveryTest(TestCase):
         }, deliveries[1])
 
     def test_url(self):
-        self.assertEqual(CreateDelivery(Order(self.order)).url(), '/rekis/api/altaEnvios')
+        self.assertEqual(
+            CreateDelivery(Order(self.order)).url(),
+            f'{lazona_connector.vars.koiki_host}/rekis/api/altaEnvios'
+        )

--- a/lazona_connector/vars.py
+++ b/lazona_connector/vars.py
@@ -4,13 +4,14 @@ import logging
 
 TESTING = len(sys.argv) > 1 and sys.argv[1] == 'test'
 
-
 if TESTING:
     koiki_host = "https://testing_host"
+    koiki_auth_token = "testing_auth_token"
+    koiki_tracking_host = "https://testing_tracking_host"
+    koiki_tracking_auth_token = "testing_autj_token"
     wcfmmp_host = "https://wcfmmp_testing_host"
     wcfmmp_user = "test_wcfmmp_user"
     wcfmmp_password = "test_wcfmmp_password"
-    auth_token = "testing_auth_token"
     error_mail_recipients = ["test@test.com"]
     logger = logging.getLogger('django.server')
     wp_host = "https://wcfmmp_testing_host"
@@ -24,10 +25,12 @@ if TESTING:
     sugarcrm_membership_roles = ["^member^", "^is_partner^"]
 else:
     koiki_host = os.getenv('KOIKI_HOST')
+    koiki_auth_token = os.getenv('KOIKI_AUTH_TOKEN')
+    koiki_tracking_host = os.getenv('KOIKI_TRACKING_HOST')
+    koiki_tracking_auth_token = os.getenv('KOIKI_TRACKING_AUTH_TOKEN')
     wcfmmp_host = os.getenv('WCFMMP_HOST')
     wcfmmp_user = os.getenv('WCFMMP_USER')
     wcfmmp_password = os.getenv('WCFMMP_PASSWORD')
-    auth_token = os.getenv('KOIKI_AUTH_TOKEN')
     error_mail_recipients = os.getenv("KOIKI_ERROR_MAIL_RECIPIENTS", "").split(",")
     logger = logging.getLogger('django.server')
     wp_host = os.getenv('WCFMMP_HOST')


### PR DESCRIPTION
As we have 2 different API implementations for koiki I think it's best when client gets agnostic about which API are we using. Instead this responsibility is passed to CreateDelivery and UpdateDelivery classes 